### PR TITLE
Group inbox by day and color label chips

### DIFF
--- a/apps/web/src/MailRow.tsx
+++ b/apps/web/src/MailRow.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, type CSSProperties } from "react";
 import { Icon, IconButton } from "./components";
 import { displayDate, type Mail } from "./data";
 
@@ -10,6 +10,17 @@ type MailRowProps = {
   sent: boolean;
   showSnippets: boolean;
 };
+
+const labelHues: Record<string, number> = { social: 250, marketing: 25, pitch: 300, news: 85, updates: 200, forums: 150, promotions: 55, finance: 130 };
+
+/** Stable hue per label so the same label reads the same color everywhere. */
+export function labelHue(label: string) {
+  const key = label.trim().toLowerCase();
+  if (key in labelHues) return labelHues[key];
+  let hash = 0;
+  for (const char of key) hash = (hash * 31 + char.codePointAt(0)!) >>> 0;
+  return hash % 360;
+}
 
 function MailRow({
   mail: m,
@@ -54,7 +65,12 @@ function MailRow({
         {showSnippets && <span className="row-snippet">{m.snippet}</span>}
       </span>
       {m.labels.length > 0 && (
-        <span className="row-label" role="cell" title={m.labels.join(", ")}>
+        <span
+          className="row-label"
+          role="cell"
+          title={m.labels.join(", ")}
+          style={{ "--label-hue": labelHue(m.labels[0]) } as CSSProperties}
+        >
           {m.labels[0]}
         </span>
       )}

--- a/apps/web/src/inbox.ts
+++ b/apps/web/src/inbox.ts
@@ -215,6 +215,14 @@ function draftHtml(value: string): string {
   return template.innerHTML;
 }
 
+/** Day-level group heading: "September 4th", plus the year once it differs from today's. */
+export function dayGroup(time: Date, today = new Date()) {
+  const day = time.getDate(), rest = day % 100;
+  const suffix = rest >= 11 && rest <= 13 ? "th" : day % 10 === 1 ? "st" : day % 10 === 2 ? "nd" : day % 10 === 3 ? "rd" : "th";
+  const month = time.toLocaleDateString([], { month: "long" });
+  return `${month} ${day}${suffix}${time.getFullYear() === today.getFullYear() ? "" : `, ${time.getFullYear()}`}`;
+}
+
 function displayTimes() {
   // One pass gets consistent calendar boundaries/default locale/timezone.
   // Recreate on the next pass, so midnight or a timezone change cannot leave
@@ -224,15 +232,13 @@ function displayTimes() {
   const yesterdayLabel = yesterday.toDateString();
   const clock = new Intl.DateTimeFormat([], { hour: "numeric", minute: "2-digit" });
   const date = new Intl.DateTimeFormat([], { month: "short", day: "numeric" });
-  const month = new Intl.DateTimeFormat([], { month: "long" });
-  const year = new Intl.DateTimeFormat([], { month: "long", year: "numeric" });
   const values = new Map<string, { date: string; group: string }>();
   const locale = clock.resolvedOptions();
   return { key: `${locale.locale}\0${locale.timeZone}\0${todayLabel}`, format: (value: string) => {
     const cached = values.get(value); if (cached) return cached;
     const time = new Date(value), day = time.toDateString(), sameDay = day === todayLabel;
     const formatted = { date: sameDay ? clock.format(time) : date.format(time),
-      group: sameDay ? "Today" : day === yesterdayLabel ? "Yesterday" : (time.getFullYear() !== today.getFullYear() ? year : month).format(time) };
+      group: sameDay ? "Today" : day === yesterdayLabel ? "Yesterday" : dayGroup(time, today) };
     values.set(value, formatted); return formatted;
   } };
 }

--- a/apps/web/src/mail-view.ts
+++ b/apps/web/src/mail-view.ts
@@ -248,12 +248,13 @@ export function selectMailView(
   const entries: MailListEntry[] = [];
   let totalHeight = 0;
   for (const [index, message] of visibleMail.entries()) {
+    // Today sits at the top unlabeled; every later day gets its own heading.
     if (
-      folder !== "Inbox" &&
       !search &&
-      index > 0 &&
       message.group &&
-      message.group !== visibleMail[index - 1].group
+      (index > 0
+        ? message.group !== visibleMail[index - 1].group
+        : message.group !== "Today")
     ) {
       entries.push({
         key: `group-${message.id}`,
@@ -261,7 +262,7 @@ export function selectMailView(
         height: 60,
         mail: message,
         index,
-        group: message.group === "August" ? "Earlier in August" : message.group,
+        group: message.group,
       });
       totalHeight += 60;
     }

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -558,11 +558,16 @@ kbd {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--muted);
+  --label-hue: 250;
+  color: oklch(0.88 0.08 var(--label-hue));
+  background: oklch(0.38 0.1 var(--label-hue));
   font-size: 10px;
-  border: 1px solid var(--border);
   border-radius: 3px;
-  padding: 1px 5px;
+  padding: 2px 5px;
+}
+[data-theme="light"] .row-label {
+  color: oklch(0.42 0.14 var(--label-hue));
+  background: oklch(0.92 0.06 var(--label-hue));
 }
 .starred-icon {
   color: #e4c377;

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -872,7 +872,7 @@ test("SDK-backed optimistic flags retain conditional intent through latency, fai
     assert.equal(result.code, 0, result.output);
     return;
   }
-  const [{ createMockHost }, { MockInboxProvider }, { ProviderError }, { InboxStore, InboxActionError }, fs, { tmpdir }, { join }, { Database }, { createAttentionFeedbackStore }] = await Promise.all([
+  const [{ createMockHost }, { MockInboxProvider }, { ProviderError }, { InboxStore, InboxActionError, dayGroup }, fs, { tmpdir }, { join }, { Database }, { createAttentionFeedbackStore }] = await Promise.all([
     import("../../mock-api/src/host.ts"), import("../../mock-api/src/provider.ts"), import("../../../packages/inbox-sdk/server/sdk/types.ts"),
     import("../src/inbox.ts"), import("node:fs/promises"), import("node:os"), import("node:path"), import("bun:sqlite"), import("../../local-host/src/attention-feedback.ts"),
   ]);
@@ -1419,7 +1419,8 @@ test("SDK-backed optimistic flags retain conditional intent through latency, fai
     assert.equal(calendarView("today").date, calendarToday.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
     assert.equal(calendarView("today").group, "Today");
     assert.equal(calendarView("yesterday").group, "Yesterday");
-    assert.equal(calendarView("year").group, calendarPreviousYear.toLocaleDateString([], { month: "long", year: "numeric" }));
+    assert.equal(calendarView("year").group, dayGroup(calendarPreviousYear, calendarToday));
+    assert.match(calendarView("year").group, /^[A-Z][a-z]+ \d{1,2}(st|nd|rd|th), \d{4}$/);
     await store.loadThread(calendarView("today").id);
     const RealDate = Date, tomorrow = new Date(calendarToday); tomorrow.setDate(tomorrow.getDate() + 1);
     try {


### PR DESCRIPTION
Mail list grouping previously applied only outside Inbox and collapsed older
mail into month buckets ("August" → "Earlier in August"). Now every folder,
including Inbox, groups by day: Today sits at the top with no heading,
followed by "Yesterday", then one heading per day ("September 4th", with the
year appended when it differs). The month/year formatters and the August
special case are removed in favor of the exported dayGroup helper.

Label chips switch from a bordered muted outline to a hue-tinted background
with a lighter tint of the same hue for text (dark and light themes). Hues are
fixed for common categories (social, marketing, pitch, news, …) and hashed for
other labels so a given label is always the same color.

Verified: bun run build:web (tsc + vite) and bun run test:web (93 pass),
including the SDK-backed calendar-label assertions updated for day groups.
