### PR TITLE
UIPR: Show receiving aliases and improve reply defaults

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -162,6 +162,7 @@ export default function App({ applicationUser, onSignOut }: { applicationUser?: 
   } | null>(null);
   const [capturingIssue, setCapturingIssue] = useState(false);
   const issueCapturePending = useRef(false);
+  const contactComposePending = useRef(false);
   const [overlayIds, setOverlayIds] = useState<string[] | null>(null);
   const [commandDraftId, setCommandDraftId] = useState<string | null>(null);
   const [teachBusy, setTeachBusy] = useState(false);
@@ -1161,13 +1162,15 @@ export default function App({ applicationUser, onSignOut }: { applicationUser?: 
     catch (error) { actionError(error); }
   }
   async function composeContact() {
-    if (!contextContact || !contextSender?.canSend) return;
+    if (!currentMail || !contextContact || !contextSender?.canSend || contactComposePending.current) return;
+    contactComposePending.current = true;
     motion.prepare("switch");
     try {
-      const draft = await store.newDraft(contextSender.id, { to: contextContact.email });
+      const draft = await store.newDraft(contextSender.id, { to: contextContact.email, mail: currentMail, sourceMessageId: contextContact.messageId ?? undefined });
       navigate({ draft: draft.id, thread: undefined, view: undefined });
       setSearch(false);
     } catch (error) { actionError(error); }
+    finally { contactComposePending.current = false; }
   }
   function updateDraft(draft: Draft) {
     const current = drafts.find(value => value.id === draft.id);

--- a/apps/web/src/Composer.tsx
+++ b/apps/web/src/Composer.tsx
@@ -1,4 +1,5 @@
 import { readText, removeSaved, writeText } from "./storage";
+import { sendingIdentityMatchesMailbox } from "inbox-sdk/sender-selection";
 import {
   useCallback,
   useEffect,
@@ -54,8 +55,8 @@ type ComposerProps = {
 /** Receiving views can overlap; expose each authorized source/address once. */
 export function sendingAddressGroups(accounts: MailboxOption[], catalog: Record<string, readonly { email: string }[] | undefined>, preferredMailbox: string) {
   const groups = accounts.map(account => ({ account, identities: (catalog[account.id] ?? (account.email ? [{ email: account.email }] : []))
-    .filter(identity => account.selectorKind === "address" ? identity.email.toLowerCase() === (account.selectorValue ?? account.email).toLowerCase()
-      : account.selectorKind === "domain" ? identity.email.split("@").at(-1)?.toLowerCase() === account.selectorValue?.toLowerCase() : true)
+    .filter(identity => sendingIdentityMatchesMailbox(identity.email, { kind: account.selectorKind,
+      value: account.selectorValue ?? (account.selectorKind === "address" ? account.email : undefined) }))
     .map(identity => ({ account: account.id, email: identity.email, value: JSON.stringify([account.id, identity.email]) })) }));
   const owners = new Map<string, string>();
   for (const group of groups) for (const identity of group.identities) {

--- a/apps/web/src/MailRow.tsx
+++ b/apps/web/src/MailRow.tsx
@@ -31,9 +31,10 @@ function MailRow({
   showSnippets,
 }: MailRowProps) {
   const messageCount = m.window ? m.window.counts.messages : m.messages.length;
-  const to = sent ? m.toAddresses?.join(", ") ?? m.to : "";
-  const recipient = sent ? (to ? `To: ${to}` : "No To recipients") : m.recipientAddress;
-  const recipientTitle = sent && to ? `To: ${m.to || to}` : recipient;
+  const receivingAddress = sent ? undefined : m.recipientAddress;
+  const to = receivingAddress ?? m.toAddresses?.join(", ") ?? m.to;
+  const recipient = to ? `To: ${to}` : "No To recipients";
+  const recipientTitle = to ? `To: ${receivingAddress ?? (m.to || to)}` : recipient;
   return (
     <div
       key={m.id}
@@ -77,7 +78,7 @@ function MailRow({
         </span>
       )}
       <span className="row-recipients" role="cell" title={recipientTitle}>
-        {recipient ?? ""}
+        {recipient}
       </span>
       <span className="row-metadata">
         {m.remindedAt !== undefined && (

--- a/apps/web/src/MailRow.tsx
+++ b/apps/web/src/MailRow.tsx
@@ -32,7 +32,7 @@ function MailRow({
 }: MailRowProps) {
   const messageCount = m.window ? m.window.counts.messages : m.messages.length;
   const to = sent ? m.toAddresses?.join(", ") ?? m.to : "";
-  const recipient = sent ? (to ? `To: ${to}` : "No To recipients") : m.recipientAlias;
+  const recipient = sent ? (to ? `To: ${to}` : "No To recipients") : m.recipientAddress;
   const recipientTitle = sent && to ? `To: ${m.to || to}` : recipient;
   return (
     <div

--- a/apps/web/src/MailRow.tsx
+++ b/apps/web/src/MailRow.tsx
@@ -30,7 +30,6 @@ function MailRow({
   sent,
   showSnippets,
 }: MailRowProps) {
-  const recipients = m.toAddresses?.join(", ") ?? m.to;
   const messageCount = m.window ? m.window.counts.messages : m.messages.length;
   return (
     <div
@@ -74,8 +73,8 @@ function MailRow({
           {m.labels[0]}
         </span>
       )}
-      <span className="row-recipients" role="cell" title={recipients ? `To: ${m.to || recipients}` : "No To recipients"}>
-        {recipients ? `To: ${recipients}` : "No To recipients"}
+      <span className="row-recipients" role="cell" title={m.recipientAlias}>
+        {m.recipientAlias ?? ""}
       </span>
       <span className="row-metadata">
         {m.remindedAt !== undefined && (

--- a/apps/web/src/MailRow.tsx
+++ b/apps/web/src/MailRow.tsx
@@ -31,6 +31,9 @@ function MailRow({
   showSnippets,
 }: MailRowProps) {
   const messageCount = m.window ? m.window.counts.messages : m.messages.length;
+  const to = sent ? m.toAddresses?.join(", ") ?? m.to : "";
+  const recipient = sent ? (to ? `To: ${to}` : "No To recipients") : m.recipientAlias;
+  const recipientTitle = sent && to ? `To: ${m.to || to}` : recipient;
   return (
     <div
       key={m.id}
@@ -73,8 +76,8 @@ function MailRow({
           {m.labels[0]}
         </span>
       )}
-      <span className="row-recipients" role="cell" title={m.recipientAlias}>
-        {m.recipientAlias ?? ""}
+      <span className="row-recipients" role="cell" title={recipientTitle}>
+        {recipient ?? ""}
       </span>
       <span className="row-metadata">
         {m.remindedAt !== undefined && (

--- a/apps/web/src/MailRow.tsx
+++ b/apps/web/src/MailRow.tsx
@@ -30,11 +30,9 @@ function MailRow({
   sent,
   showSnippets,
 }: MailRowProps) {
-  const messageCount = m.window ? m.window.counts.messages : m.messages.length;
   const receivingAddress = sent ? undefined : m.recipientAddress;
-  const to = receivingAddress ?? m.toAddresses?.join(", ") ?? m.to;
-  const recipient = to ? `To: ${to}` : "No To recipients";
-  const recipientTitle = to ? `To: ${receivingAddress ?? (m.to || to)}` : recipient;
+  const recipients = receivingAddress ?? m.toAddresses?.join(", ") ?? m.to;
+  const messageCount = m.window ? m.window.counts.messages : m.messages.length;
   return (
     <div
       key={m.id}
@@ -77,8 +75,8 @@ function MailRow({
           {m.labels[0]}
         </span>
       )}
-      <span className="row-recipients" role="cell" title={recipientTitle}>
-        {recipient}
+      <span className="row-recipients" role="cell" title={recipients ? `To: ${receivingAddress ?? (m.to || recipients)}` : "No To recipients"}>
+        {recipients ? `To: ${recipients}` : "No To recipients"}
       </span>
       <span className="row-metadata">
         {m.remindedAt !== undefined && (

--- a/apps/web/src/ThreadView.tsx
+++ b/apps/web/src/ThreadView.tsx
@@ -686,7 +686,9 @@ export default function ThreadView({
               {unsubscribed ? "Unsubscribed" : "Unsubscribe"}
             </button>
           )}
-          {!!mail.mailboxNames?.length && <div className="thread-mailbox-origin" title={mail.mailboxNames.join(", ")}>{mail.mailboxNames[0]}{mail.mailboxNames.length > 1 ? ` +${mail.mailboxNames.length - 1} mailboxes` : ""}</div>}
+          {mail.recipientAlias ? (
+            <div className="thread-mailbox-origin" title={mail.recipientAlias}>{mail.recipientAlias}</div>
+          ) : !!mail.mailboxNames?.length && <div className="thread-mailbox-origin" title={mail.mailboxNames.join(", ")}>{mail.mailboxNames[0]}{mail.mailboxNames.length > 1 ? ` +${mail.mailboxNames.length - 1} mailboxes` : ""}</div>}
           {!!mail.labels.length && (
             <div className="thread-labels">
               {mail.labels.map((label) => (

--- a/apps/web/src/ThreadView.tsx
+++ b/apps/web/src/ThreadView.tsx
@@ -686,8 +686,8 @@ export default function ThreadView({
               {unsubscribed ? "Unsubscribed" : "Unsubscribe"}
             </button>
           )}
-          {mail.recipientAlias ? (
-            <div className="thread-mailbox-origin" title={mail.recipientAlias}>{mail.recipientAlias}</div>
+          {mail.recipientAddress ? (
+            <div className="thread-mailbox-origin" title={mail.recipientAddress}>{mail.recipientAddress}</div>
           ) : !!mail.mailboxNames?.length && <div className="thread-mailbox-origin" title={mail.mailboxNames.join(", ")}>{mail.mailboxNames[0]}{mail.mailboxNames.length > 1 ? ` +${mail.mailboxNames.length - 1} mailboxes` : ""}</div>}
           {!!mail.labels.length && (
             <div className="thread-labels">

--- a/apps/web/src/data.ts
+++ b/apps/web/src/data.ts
@@ -93,6 +93,7 @@ export type Mail = {
   mailboxId?: string;
   sdkThreadId?: string;
   accountEmail?: string;
+  recipientAlias?: string;
   locations?: string[];
   operationId?: string;
   mailboxIds?: string[];

--- a/apps/web/src/data.ts
+++ b/apps/web/src/data.ts
@@ -93,7 +93,7 @@ export type Mail = {
   mailboxId?: string;
   sdkThreadId?: string;
   accountEmail?: string;
-  recipientAlias?: string;
+  recipientAddress?: string;
   locations?: string[];
   operationId?: string;
   mailboxIds?: string[];

--- a/apps/web/src/inbox.ts
+++ b/apps/web/src/inbox.ts
@@ -16,7 +16,7 @@ import { getApplicationStorage } from "./storage";
 import { createScopedFetch } from "./application-auth";
 import { getApplicationScope } from "./application-scope";
 import { matchesSearch } from "./mail-search";
-import { hasIncomingRecipientHeaders, matchingRecipientAlias } from "./recipient-alias";
+import { hasIncomingRecipientHeaders, matchingRecipientAddress, matchingRecipientAlias } from "./recipient-alias";
 import { readHostConfiguration, readInboxViewPreferences, writeInboxViewPreferences, createAiTriageClient, type HostConfiguration, type InboxViewPreferences, createCategoryTransport, CategoryRequestError } from "./host";
 import { readSplitPreferences, writeSplitPreferences, readAttentionFeedback, recordAttentionFeedback, retractAttentionFeedback, InboxViewPreferencesError,
   type SavedSplitPreferences, type AttentionFeedback, type AttentionFeedbackTarget } from "./host";
@@ -2138,7 +2138,7 @@ export class InboxStore {
       const aliases = source && this.recipientAliases.get(source.id);
       const recipientAlias = source && aliases?.generation === source.generation
         && provenance.messagesComplete
-        ? matchingRecipientAlias(retained.get(row.key)!, aliases.identities, source.email) : undefined;
+        ? matchingRecipientAddress(retained.get(row.key)!, aliases.identities, source.email) : undefined;
       // Whole-conversation aggregate/provenance always wins over partial projected metadata.
       const time = Number.isFinite(row.mail.receivedAt) ? calendar.format(new Date(row.mail.receivedAt!).toISOString()) : { date: row.mail.date, group: row.mail.group };
       let next: Mail = { ...row.mail, ...time, recipientAlias, messages: local?.messages.filter(message => ids.has(message.id)) ?? row.mail.messages, window: provenance,
@@ -2326,7 +2326,7 @@ export class InboxStore {
         ? [...(unifiedAliasRows.get(nativeKey(conversation.sourceId, conversation.sdkThreadId))?.values() ?? [])]
         : aliasRows.get(conversation.id) ?? [];
       conversation.recipientAlias = source && cached?.generation === source.generation
-        ? matchingRecipientAlias(rows, cached.identities, source.email) : undefined;
+        ? matchingRecipientAddress(rows, cached.identities, source.email) : undefined;
     }
     if (!onlyThreads) this.knownThreads.clear();
     const ai = this.state.ai;

--- a/apps/web/src/inbox.ts
+++ b/apps/web/src/inbox.ts
@@ -16,7 +16,8 @@ import { getApplicationStorage } from "./storage";
 import { createScopedFetch } from "./application-auth";
 import { getApplicationScope } from "./application-scope";
 import { matchesSearch } from "./mail-search";
-import { hasIncomingRecipientHeaders, matchingRecipientAddress, matchingRecipientAlias, type RecipientIdentity } from "./recipient-address";
+import { hasIncomingRecipientHeaders, matchingRecipientAddress, type RecipientIdentity } from "./recipient-address";
+import { senderFromRecipients } from "inbox-sdk/sender-selection";
 import { readHostConfiguration, readInboxViewPreferences, writeInboxViewPreferences, createAiTriageClient, type HostConfiguration, type InboxViewPreferences, createCategoryTransport, CategoryRequestError } from "./host";
 import { readSplitPreferences, writeSplitPreferences, readAttentionFeedback, recordAttentionFeedback, retractAttentionFeedback, InboxViewPreferencesError,
   type SavedSplitPreferences, type AttentionFeedback, type AttentionFeedbackTarget } from "./host";
@@ -2595,7 +2596,7 @@ export class InboxStore {
       const selector = box.selector;
       const eligible = catalog.identities.filter(identity => selector.kind === "address" ? identity.email.toLowerCase() === selector.value.toLowerCase()
         : selector.kind === "domain" ? identity.email.split("@").at(-1)?.toLowerCase() === selector.value.toLowerCase() : true);
-      from = matchingRecipientAlias([context], eligible, source.email) ?? from;
+      from = senderFromRecipients(context, eligible) ?? from;
     }
     // Contact composition borrows only the sender identity, not reply threading or content.
     const raw = await this.client.createDraft({ accountId: source.id, mailboxId: box.id, ...(!implicitReply ? { from } : {}),

--- a/apps/web/src/inbox.ts
+++ b/apps/web/src/inbox.ts
@@ -1302,6 +1302,13 @@ export class InboxStore {
   private scheduleRecipientIdentityReads(rows: readonly { sourceId: string; sourceGeneration: number }[]) {
     const now = Date.now();
     this.recipientIdentityActive = new Set(rows.map(row => `${row.sourceId}\0${row.sourceGeneration}`));
+    // Paging can retire demand without opening a new window. Drop only queued work;
+    // in-flight requests retain their completion fences and worker ownership.
+    for (const [key, request] of this.recipientIdentityQueue) {
+      if (this.recipientIdentityActive.has(key)) continue;
+      this.recipientIdentityQueue.delete(key);
+      if (this.recipientIdentityLoads.get(key) === request) this.recipientIdentityLoads.delete(key);
+    }
     for (const row of rows) {
       const source = this.sourceAccounts.find(account => account.id === row.sourceId);
       if (!source || source.status !== "connected" || source.generation !== row.sourceGeneration) continue;
@@ -1339,6 +1346,11 @@ export class InboxStore {
       const [key, request] = this.recipientIdentityQueue.entries().next().value!;
       this.recipientIdentityQueue.delete(key);
       const storeGeneration = request.storeGeneration;
+      if (request.demandEpoch !== this.recipientIdentityDemandEpoch || !this.recipientIdentityActive.has(key)
+        || !this.recipientSourceIsCurrent(request.sourceId, request.generation, storeGeneration)) {
+        if (this.recipientIdentityLoads.get(key) === request) this.recipientIdentityLoads.delete(key);
+        continue;
+      }
       const signal = AbortSignal.any([this.recipientIdentityController.signal, this.controller.signal, this.applicationScope.signal]);
       let worker!: Promise<void>;
       worker = (async () => {

--- a/apps/web/src/inbox.ts
+++ b/apps/web/src/inbox.ts
@@ -16,6 +16,7 @@ import { getApplicationStorage } from "./storage";
 import { createScopedFetch } from "./application-auth";
 import { getApplicationScope } from "./application-scope";
 import { matchesSearch } from "./mail-search";
+import { hasIncomingRecipientHeaders, matchingRecipientAlias } from "./recipient-alias";
 import { readHostConfiguration, readInboxViewPreferences, writeInboxViewPreferences, createAiTriageClient, type HostConfiguration, type InboxViewPreferences, createCategoryTransport, CategoryRequestError } from "./host";
 import { readSplitPreferences, writeSplitPreferences, readAttentionFeedback, recordAttentionFeedback, retractAttentionFeedback, InboxViewPreferencesError,
   type SavedSplitPreferences, type AttentionFeedback, type AttentionFeedbackTarget } from "./host";
@@ -48,6 +49,8 @@ const viewKey = (query: InboxViewQuery) => JSON.stringify(query);
 const expiredQuery = (error: unknown) => error instanceof InboxViewPreferencesError && error.code === "HOST_INBOX_QUERY_EXPIRED";
 type ThreadHistory = { contextVersion: string; summaries: MailboxMessageSummary[]; cursor: string | null; exhausted: boolean; truncated?: boolean; error?: string };
 type ThreadValidation = { row: InboxWindowRow; controller: AbortController; promise: Promise<{ summaries: MailboxMessageSummary[]; error?: string }> };
+type RecipientAliasIdentity = { email: string; isPrimary: boolean };
+type RecipientAliasRequest = { key: string; sourceId: string; generation: number; storeGeneration: number; demandEpoch: number; mode: "window" | "legacy" };
 class DraftRecipientError extends Error {}
 type SendReference = { id: string; draftId: string; accountId: string; mailboxId: string };
 type Sending = { ref: SendReference; operation: Operation; draft: SdkDraft };
@@ -159,6 +162,8 @@ const MAX_ISSUES = 4;
 const RESOLVE_HOLD_MS = 10_000;
 /** A dismissed problem that recurs within this window starts hidden instead of reopening. */
 const DISMISSAL_MEMORY_MS = 5 * 60_000;
+const RECIPIENT_ALIAS_TTL_MS = 5 * 60_000;
+const RECIPIENT_ALIAS_CONCURRENCY = 4;
 /** Change-history polling cadence while the event stream is unavailable. */
 const POLL_MS = 30_000;
 const MAX_BACKOFF_MS = 60_000;
@@ -295,6 +300,15 @@ export class InboxStore {
   private bodyEpoch = 0;
   private blobInfo = new Map<string, BlobInfo>();
   private folders = new Map<string, Folder[]>();
+  private recipientAliases = new Map<string, { generation: number; checkedAt: number; identities: RecipientAliasIdentity[] }>();
+  private recipientAliasQueue = new Map<string, RecipientAliasRequest>();
+  private recipientAliasLoads = new Map<string, RecipientAliasRequest>();
+  private recipientAliasWorkers = new Set<Promise<void>>();
+  private recipientAliasActive = new Set<string>();
+  private legacyRecipientDemand = new Map<string, { sourceId: string; sourceGeneration: number }>();
+  private recipientAliasDemandEpoch = 0;
+  private recipientAliasController = new AbortController();
+  private recipientAliasRefreshTimer?: ReturnType<typeof setTimeout>;
   private folderDiscovery?: Promise<void>;
   private discoveredFolders = new Set<string>();
   private labels: Label[] = [];
@@ -433,6 +447,7 @@ export class InboxStore {
   private restoreWindow(view: RetainedView): Promise<void> {
     const query = { ...this.windowQuery }, epoch = ++this.windowEpoch, generation = this.generation;
     this.windowController.abort(); this.windowController = new AbortController();
+    this.resetRecipientAliasDemand();
     this.clearThreadMessagePins();
     // An aborted open or drain of the previous view must not gate this view's reconciliation.
     this.windowLoading = undefined; this.windowPaging = undefined; this.windowChanges = undefined;
@@ -700,6 +715,7 @@ export class InboxStore {
   private openWindow = (): Promise<void> => {
     const query = { ...this.windowQuery }, epoch = ++this.windowEpoch, generation = this.generation;
     this.windowController.abort(); this.windowController = new AbortController();
+    this.resetRecipientAliasDemand();
     this.clearThreadMessagePins();
     this.windowPaging = undefined; this.windowChanges = undefined; this.windowReplayCheckpoint = undefined; this.windowBoundaryCursors.clear(); this.windowNewerCursor = null; this.windowLocalRemoved.clear(); this.windowRemovalFences.clear(); this.windowAutoDone = false;
     const signal = AbortSignal.any([this.windowController.signal, this.controller.signal]);
@@ -1258,6 +1274,100 @@ export class InboxStore {
     if (!box || !source) throw new Error("Select a connected mailbox first.");
     return { box, source };
   }
+  private pruneRecipientAliases(accounts: readonly Account[]) {
+    for (const [sourceId, cached] of this.recipientAliases) {
+      const source = accounts.find(account => account.id === sourceId);
+      if (source?.status !== "connected" || source.generation !== cached.generation) this.recipientAliases.delete(sourceId);
+    }
+  }
+  private resetRecipientAliasDemand() {
+    this.recipientAliasDemandEpoch++;
+    this.recipientAliasController.abort(); this.recipientAliasController = new AbortController();
+    this.recipientAliasQueue.clear(); this.recipientAliasLoads.clear(); this.recipientAliasWorkers.clear(); this.recipientAliasActive.clear();
+    clearTimeout(this.recipientAliasRefreshTimer); this.recipientAliasRefreshTimer = undefined;
+  }
+  private recipientSourceIsCurrent(sourceId: string, sourceGeneration: number, storeGeneration: number): boolean {
+    if (storeGeneration !== this.generation || this.controller.signal.aborted || this.applicationScope.signal.aborted) return false;
+    const source = this.sourceAccounts.find(account => account.id === sourceId);
+    if (!this.state.host?.inboxWindow) return source?.generation === sourceGeneration && source.status === "connected"
+      && this.recipientAliasActive.has(`${sourceId}\0${sourceGeneration}`);
+    const window = this.state.window;
+    return source?.generation === sourceGeneration && source.status === "connected" && !!window
+      && window.state.sources.some(value => value.sourceId === sourceId && value.generation === sourceGeneration)
+      && window.keys.some(key => {
+        const row = this.windowRows.get(key);
+        return row?.sourceId === sourceId && row.sourceGeneration === sourceGeneration;
+      });
+  }
+  private scheduleRecipientAliases(rows: readonly { sourceId: string; sourceGeneration: number }[]) {
+    const now = Date.now();
+    this.recipientAliasActive = new Set(rows.map(row => `${row.sourceId}\0${row.sourceGeneration}`));
+    for (const row of rows) {
+      const source = this.sourceAccounts.find(account => account.id === row.sourceId);
+      if (!source || source.status !== "connected" || source.generation !== row.sourceGeneration) continue;
+      const current = this.recipientAliases.get(source.id);
+      const key = `${source.id}\0${source.generation}`;
+      if (current?.generation === source.generation && now - current.checkedAt < RECIPIENT_ALIAS_TTL_MS
+        || this.recipientAliasLoads.has(key)) continue;
+      const request: RecipientAliasRequest = { key, sourceId: source.id, generation: source.generation, storeGeneration: this.generation,
+        demandEpoch: this.recipientAliasDemandEpoch, mode: this.state.host?.inboxWindow ? "window" : "legacy" };
+      this.recipientAliasLoads.set(key, request);
+      this.recipientAliasQueue.set(key, request);
+    }
+    this.drainRecipientAliases();
+  }
+  private scheduleRecipientAliasRefresh() {
+    clearTimeout(this.recipientAliasRefreshTimer);
+    this.recipientAliasRefreshTimer = undefined;
+    const active = this.recipientAliasActive;
+    const next = Math.min(...[...this.recipientAliases.entries()].flatMap(([sourceId, cached]) => {
+      const key = `${sourceId}\0${cached.generation}`;
+      return active.has(key) && !this.recipientAliasLoads.has(key) ? [cached.checkedAt + RECIPIENT_ALIAS_TTL_MS] : [];
+    }));
+    if (!Number.isFinite(next)) return;
+    this.recipientAliasRefreshTimer = setTimeout(() => {
+      this.recipientAliasRefreshTimer = undefined;
+      if (this.state.host?.inboxWindow) this.rebuildWindow();
+      else {
+        this.scheduleRecipientAliases([...this.legacyRecipientDemand.values()]);
+        this.scheduleRecipientAliasRefresh();
+      }
+    }, Math.max(1, next - Date.now()));
+  }
+  private drainRecipientAliases() {
+    while (this.recipientAliasWorkers.size < RECIPIENT_ALIAS_CONCURRENCY && this.recipientAliasQueue.size) {
+      const [key, request] = this.recipientAliasQueue.entries().next().value!;
+      this.recipientAliasQueue.delete(key);
+      const storeGeneration = request.storeGeneration;
+      const signal = AbortSignal.any([this.recipientAliasController.signal, this.controller.signal, this.applicationScope.signal]);
+      let worker!: Promise<void>;
+      worker = (async () => {
+        let identities: RecipientAliasIdentity[] = [];
+        try {
+          const result = await this.client.sendingIdentities(request.sourceId, {}, { signal });
+          if (result.sourceId !== request.sourceId) throw new Error("Recipient identity source changed");
+          identities = result.identities.map(identity => ({ email: identity.email, isPrimary: identity.isPrimary }));
+        } catch {
+          // Recipient metadata is optional. A failed discovery leaves the column blank until the bounded cache expires.
+        }
+        if (signal.aborted || request.demandEpoch !== this.recipientAliasDemandEpoch
+          || !this.recipientSourceIsCurrent(request.sourceId, request.generation, storeGeneration)) return;
+        const previous = this.recipientAliases.get(request.sourceId);
+        this.recipientAliases.set(request.sourceId, { generation: request.generation, checkedAt: Date.now(), identities });
+        if (previous?.generation !== request.generation || JSON.stringify(previous.identities) !== JSON.stringify(identities)) {
+          if (request.mode === "window") this.rebuildWindow();
+          else this.rebuild(new Set([...this.legacyRecipientDemand.entries()]
+            .filter(([, value]) => value.sourceId === request.sourceId).map(([thread]) => thread)));
+        }
+      })().finally(() => {
+        if (!this.recipientAliasWorkers.delete(worker)) return;
+        if (this.recipientAliasLoads.get(key) === request) this.recipientAliasLoads.delete(key);
+        this.scheduleRecipientAliasRefresh();
+        this.drainRecipientAliases();
+      });
+      this.recipientAliasWorkers.add(worker);
+    }
+  }
   sendingIdentities: LoadSendingIdentities = async (mailboxId, input = {}) => {
     const { source } = this.account(mailboxId);
     const generation = this.generation, signal = this.controller.signal;
@@ -1434,6 +1544,9 @@ export class InboxStore {
       this.clearPendingDone();
       this.retainedViews.clear(); this.windowCounts = undefined;
       this.client.clearCache();
+      this.resetRecipientAliasDemand(); this.recipientAliases.clear();
+      this.legacyRecipientDemand.clear();
+      clearTimeout(this.recipientAliasRefreshTimer); this.recipientAliasRefreshTimer = undefined;
       clearTimeout(this.refreshTimer); clearTimeout(this.importantTimer); this.importantDeadline = Infinity;
       clearTimeout(this.aiPollTimer); clearTimeout(this.aiHoldTimer); this.aiPollPromise = undefined; this.aiHolds.clear();
       clearTimeout(this.aiRebuildTimer); this.aiRebuildTimer = undefined; this.aiRebuildThreads.clear();
@@ -1658,6 +1771,7 @@ export class InboxStore {
       for (const account of accounts) if (!same(presentation(account), presentation(previousAccounts.find(previous => previous.id === account.id)))) affectedSources.add(account.id);
       for (const box of selected) if (!same(box, this.boxes.find(previous => previous.id === box.id))) affectedSources.add(box.sourceId);
       this.sourceAccounts = accounts; this.boxes = selected;
+      this.pruneRecipientAliases(accounts);
       if (!same(accounts, this.state.sources) || !same(selected, this.state.mailboxes)) this.publish({ sources: accounts, mailboxes: selected });
       const folderSources = new Set(events.filter(event => event.type === "account.updated" && event.accountId).map(event => event.accountId!));
       for (const id of folderSources) if (accounts.some(account => account.id === id && account.status === "connected")) {
@@ -1892,6 +2006,7 @@ export class InboxStore {
       }
       this.operations = operations;
       this.sourceAccounts = accounts; this.boxes = selected; this.labels = labels; this.summaries = summaries; this.sending = sending;
+      this.pruneRecipientAliases(accounts);
       if (!host.inboxWindow) {
       this.messageRows = new Map([...summaries.values()].flat().map(row => [nativeKey(row.sourceId, row.id), row]));
       this.summaryFences = new Map([...this.messageRows].map(([key, row]) => [key, { epoch: flagEpoch, revision: row.revision }]));
@@ -1988,6 +2103,10 @@ export class InboxStore {
   private rebuildWindow() {
     const calendar = displayTimes(); this.calendarKey = calendar.key;
     const rows = [...this.windowRows.values()], retained = new Map(rows.map(row => [row.key, this.threadSummaries(row).summaries]));
+    const activeKeys = new Set(this.state.window?.keys ?? []);
+    this.scheduleRecipientAliases(rows.filter(row => activeKeys.has(row.key)
+      && hasIncomingRecipientHeaders(retained.get(row.key)!)));
+    this.scheduleRecipientAliasRefresh();
     const summaries = new Map<string, MailboxMessageSummary>();
     for (const row of rows) for (const summary of retained.get(row.key)!) {
       const key = nativeKey(summary.sourceId, summary.id), previous = summaries.get(key);
@@ -2015,9 +2134,14 @@ export class InboxStore {
       const local = byId.get(row.key), detail = this.windowDetails.get(row.key), provenance = this.rowProvenance(row);
       const ids = new Set(retained.get(row.key)!.map(summary => summary.id));
       if (detail?.exhausted && row.counts.messages === ids.size) { provenance.messagesComplete = true; provenance.actionContextComplete = row.targetsComplete; }
+      const source = this.sourceAccounts.find(source => source.id === row.sourceId && source.generation === row.sourceGeneration);
+      const aliases = source && this.recipientAliases.get(source.id);
+      const recipientAlias = source && aliases?.generation === source.generation
+        && provenance.messagesComplete
+        ? matchingRecipientAlias(retained.get(row.key)!, aliases.identities, source.email) : undefined;
       // Whole-conversation aggregate/provenance always wins over partial projected metadata.
       const time = Number.isFinite(row.mail.receivedAt) ? calendar.format(new Date(row.mail.receivedAt!).toISOString()) : { date: row.mail.date, group: row.mail.group };
-      let next: Mail = { ...row.mail, ...time, messages: local?.messages.filter(message => ids.has(message.id)) ?? row.mail.messages, window: provenance,
+      let next: Mail = { ...row.mail, ...time, recipientAlias, messages: local?.messages.filter(message => ids.has(message.id)) ?? row.mail.messages, window: provenance,
         hasAttachments: row.mail.hasAttachments ?? (row.messagesComplete ? row.mail.messages.some(message => message.hasAttachments) : undefined), historyExhausted: detail?.exhausted ?? row.messagesComplete,
         historyTruncated: detail?.truncated || undefined, historyError: detail?.error };
       const overlay = row.summaries.some(summary => this.projectFlags(summary) !== summary);
@@ -2086,6 +2210,11 @@ export class InboxStore {
         canSend: this.state.host?.allowProviderWrites === true && source.status === "connected" && box.status === "active" && source.capabilities.send && !!box.defaultSender };
     });
     const mail: Mail[] = [], labelNames: Record<string, string[]> = {};
+    if (!onlyThreads) this.legacyRecipientDemand.clear();
+    else for (const key of onlyThreads) this.legacyRecipientDemand.delete(key);
+    const aliasRows = new Map<string, MailboxMessageSummary[]>();
+    const unifiedAliasRows = new Map<string, Map<string, MailboxMessageSummary>>();
+    const includedAliases = new Set(this.unifiedMailboxIds());
     const senderHistory = new Map<string, SenderHistoryMessage>();
     const sentMessages = new Map<string, Operation>();
     for (const operation of this.operations.values()) if (operation.type === "send") {
@@ -2115,6 +2244,14 @@ export class InboxStore {
         const group = groups.get(row.threadId) ?? []; group.push(row); groups.set(row.threadId, group);
       }
       for (const [thread, rows] of groups) {
+        const key = nativeKey(source.id, thread);
+        aliasRows.set(viewThreadId(box.id, thread), rows);
+        if (hasIncomingRecipientHeaders(rows)) this.legacyRecipientDemand.set(key, { sourceId: source.id, sourceGeneration: source.generation });
+        if (includedAliases.has(box.id)) {
+          const combined = unifiedAliasRows.get(key) ?? new Map<string, MailboxMessageSummary>();
+          for (const row of rows) if ((combined.get(row.id)?.revision ?? -1) <= row.revision) combined.set(row.id, row);
+          unifiedAliasRows.set(key, combined);
+        }
         rows.sort((a, b) => a.receivedAt.localeCompare(b.receivedAt) || a.id.localeCompare(b.id));
         const latest = rows.at(-1)!;
         const states = rows.map(row => row.memberships.find(state => state.mailboxId === box.id)!);
@@ -2179,6 +2316,18 @@ export class InboxStore {
     const included = this.unifiedMailboxIds();
     labelNames[UNIFIED_ACCOUNT] = [...new Set(included.flatMap(id => labelNames[id] ?? []))];
     mail.push(...unifiedMail(mail, included, accounts));
+    this.scheduleRecipientAliases([...this.legacyRecipientDemand.values()]);
+    this.scheduleRecipientAliasRefresh();
+    for (const conversation of mail) {
+      if (conversation.operationId || !conversation.sourceId || !conversation.sdkThreadId) continue;
+      const source = this.sourceAccounts.find(source => source.id === conversation.sourceId);
+      const cached = this.recipientAliases.get(conversation.sourceId);
+      const rows = conversation.account === UNIFIED_ACCOUNT
+        ? [...(unifiedAliasRows.get(nativeKey(conversation.sourceId, conversation.sdkThreadId))?.values() ?? [])]
+        : aliasRows.get(conversation.id) ?? [];
+      conversation.recipientAlias = source && cached?.generation === source.generation
+        ? matchingRecipientAlias(rows, cached.identities, source.email) : undefined;
+    }
     if (!onlyThreads) this.knownThreads.clear();
     const ai = this.state.ai;
     const connectedSources = new Set(this.sourceAccounts.filter(source => source.status === "connected").map(source => source.id));

--- a/apps/web/src/inbox.ts
+++ b/apps/web/src/inbox.ts
@@ -16,8 +16,9 @@ import { getApplicationStorage } from "./storage";
 import { createScopedFetch } from "./application-auth";
 import { getApplicationScope } from "./application-scope";
 import { matchesSearch } from "./mail-search";
-import { hasIncomingRecipientHeaders, matchingRecipientAddress, type RecipientIdentity } from "./recipient-address";
-import { senderFromRecipients } from "inbox-sdk/sender-selection";
+import { hasIncomingRecipientHeaders, matchingRecipientAddress } from "./recipient-address";
+import { RecipientIdentityLoader, type RecipientIdentitySource } from "./recipient-identities";
+import { senderFromRecipients, sendingIdentityMatchesMailbox } from "inbox-sdk/sender-selection";
 import { readHostConfiguration, readInboxViewPreferences, writeInboxViewPreferences, createAiTriageClient, type HostConfiguration, type InboxViewPreferences, createCategoryTransport, CategoryRequestError } from "./host";
 import { readSplitPreferences, writeSplitPreferences, readAttentionFeedback, recordAttentionFeedback, retractAttentionFeedback, InboxViewPreferencesError,
   type SavedSplitPreferences, type AttentionFeedback, type AttentionFeedbackTarget } from "./host";
@@ -50,7 +51,6 @@ const viewKey = (query: InboxViewQuery) => JSON.stringify(query);
 const expiredQuery = (error: unknown) => error instanceof InboxViewPreferencesError && error.code === "HOST_INBOX_QUERY_EXPIRED";
 type ThreadHistory = { contextVersion: string; summaries: MailboxMessageSummary[]; cursor: string | null; exhausted: boolean; truncated?: boolean; error?: string };
 type ThreadValidation = { row: InboxWindowRow; controller: AbortController; promise: Promise<{ summaries: MailboxMessageSummary[]; error?: string }> };
-type RecipientIdentityRequest = { key: string; sourceId: string; generation: number; storeGeneration: number; demandEpoch: number; mode: "window" | "legacy" };
 class DraftRecipientError extends Error {}
 type SendReference = { id: string; draftId: string; accountId: string; mailboxId: string };
 type Sending = { ref: SendReference; operation: Operation; draft: SdkDraft };
@@ -162,8 +162,6 @@ const MAX_ISSUES = 4;
 const RESOLVE_HOLD_MS = 10_000;
 /** A dismissed problem that recurs within this window starts hidden instead of reopening. */
 const DISMISSAL_MEMORY_MS = 5 * 60_000;
-const RECIPIENT_IDENTITY_TTL_MS = 5 * 60_000;
-const RECIPIENT_IDENTITY_CONCURRENCY = 4;
 /** Change-history polling cadence while the event stream is unavailable. */
 const POLL_MS = 30_000;
 const MAX_BACKOFF_MS = 60_000;
@@ -300,15 +298,20 @@ export class InboxStore {
   private bodyEpoch = 0;
   private blobInfo = new Map<string, BlobInfo>();
   private folders = new Map<string, Folder[]>();
-  private recipientIdentityCache = new Map<string, { generation: number; checkedAt: number; identities: RecipientIdentity[] }>();
-  private recipientIdentityQueue = new Map<string, RecipientIdentityRequest>();
-  private recipientIdentityLoads = new Map<string, RecipientIdentityRequest>();
-  private recipientIdentityWorkers = new Set<Promise<void>>();
-  private recipientIdentityActive = new Set<string>();
-  private legacyRecipientDemand = new Map<string, { sourceId: string; sourceGeneration: number }>();
-  private recipientIdentityDemandEpoch = 0;
-  private recipientIdentityController = new AbortController();
-  private recipientIdentityRefreshTimer?: ReturnType<typeof setTimeout>;
+  private legacyRecipientDemand = new Map<string, RecipientIdentitySource>();
+  private readonly recipientIdentities = new RecipientIdentityLoader({
+    load: (sourceId, signal) => this.client.sendingIdentities(sourceId, {}, { signal }),
+    isCurrent: (sourceId, sourceGeneration, storeGeneration) => this.recipientSourceIsCurrent(sourceId, sourceGeneration, storeGeneration),
+    changed: (sourceId, mode) => {
+      if (mode === "window") this.rebuildWindow();
+      else this.rebuild(new Set([...this.legacyRecipientDemand.entries()]
+        .filter(([, value]) => value.sourceId === sourceId).map(([thread]) => thread)));
+    },
+    refresh: () => {
+      if (this.state.host?.inboxWindow) this.rebuildWindow();
+      else this.scheduleRecipientIdentityReads([...this.legacyRecipientDemand.values()]);
+    },
+  });
   private folderDiscovery?: Promise<void>;
   private discoveredFolders = new Set<string>();
   private labels: Label[] = [];
@@ -447,7 +450,7 @@ export class InboxStore {
   private restoreWindow(view: RetainedView): Promise<void> {
     const query = { ...this.windowQuery }, epoch = ++this.windowEpoch, generation = this.generation;
     this.windowController.abort(); this.windowController = new AbortController();
-    this.resetRecipientIdentityDemand();
+    this.recipientIdentities.reset();
     this.clearThreadMessagePins();
     // An aborted open or drain of the previous view must not gate this view's reconciliation.
     this.windowLoading = undefined; this.windowPaging = undefined; this.windowChanges = undefined;
@@ -715,7 +718,7 @@ export class InboxStore {
   private openWindow = (): Promise<void> => {
     const query = { ...this.windowQuery }, epoch = ++this.windowEpoch, generation = this.generation;
     this.windowController.abort(); this.windowController = new AbortController();
-    this.resetRecipientIdentityDemand();
+    this.recipientIdentities.reset();
     this.clearThreadMessagePins();
     this.windowPaging = undefined; this.windowChanges = undefined; this.windowReplayCheckpoint = undefined; this.windowBoundaryCursors.clear(); this.windowNewerCursor = null; this.windowLocalRemoved.clear(); this.windowRemovalFences.clear(); this.windowAutoDone = false;
     const signal = AbortSignal.any([this.windowController.signal, this.controller.signal]);
@@ -1274,23 +1277,11 @@ export class InboxStore {
     if (!box || !source) throw new Error("Select a connected mailbox first.");
     return { box, source };
   }
-  private pruneRecipientIdentities(accounts: readonly Account[]) {
-    for (const [sourceId, cached] of this.recipientIdentityCache) {
-      const source = accounts.find(account => account.id === sourceId);
-      if (source?.status !== "connected" || source.generation !== cached.generation) this.recipientIdentityCache.delete(sourceId);
-    }
-  }
-  private resetRecipientIdentityDemand() {
-    this.recipientIdentityDemandEpoch++;
-    this.recipientIdentityController.abort(); this.recipientIdentityController = new AbortController();
-    this.recipientIdentityQueue.clear(); this.recipientIdentityLoads.clear(); this.recipientIdentityWorkers.clear(); this.recipientIdentityActive.clear();
-    clearTimeout(this.recipientIdentityRefreshTimer); this.recipientIdentityRefreshTimer = undefined;
-  }
   private recipientSourceIsCurrent(sourceId: string, sourceGeneration: number, storeGeneration: number): boolean {
     if (storeGeneration !== this.generation || this.controller.signal.aborted || this.applicationScope.signal.aborted) return false;
     const source = this.sourceAccounts.find(account => account.id === sourceId);
     if (!this.state.host?.inboxWindow) return source?.generation === sourceGeneration && source.status === "connected"
-      && this.recipientIdentityActive.has(`${sourceId}\0${sourceGeneration}`);
+      && this.recipientIdentities.hasDemand(sourceId, sourceGeneration);
     const window = this.state.window;
     return source?.generation === sourceGeneration && source.status === "connected" && !!window
       && window.state.sources.some(value => value.sourceId === sourceId && value.generation === sourceGeneration)
@@ -1299,86 +1290,9 @@ export class InboxStore {
         return row?.sourceId === sourceId && row.sourceGeneration === sourceGeneration;
       });
   }
-  private scheduleRecipientIdentityReads(rows: readonly { sourceId: string; sourceGeneration: number }[]) {
-    const now = Date.now();
-    this.recipientIdentityActive = new Set(rows.map(row => `${row.sourceId}\0${row.sourceGeneration}`));
-    // Paging can retire demand without opening a new window. Drop only queued work;
-    // in-flight requests retain their completion fences and worker ownership.
-    for (const [key, request] of this.recipientIdentityQueue) {
-      if (this.recipientIdentityActive.has(key)) continue;
-      this.recipientIdentityQueue.delete(key);
-      if (this.recipientIdentityLoads.get(key) === request) this.recipientIdentityLoads.delete(key);
-    }
-    for (const row of rows) {
-      const source = this.sourceAccounts.find(account => account.id === row.sourceId);
-      if (!source || source.status !== "connected" || source.generation !== row.sourceGeneration) continue;
-      const current = this.recipientIdentityCache.get(source.id);
-      const key = `${source.id}\0${source.generation}`;
-      if (current?.generation === source.generation && now - current.checkedAt < RECIPIENT_IDENTITY_TTL_MS
-        || this.recipientIdentityLoads.has(key)) continue;
-      const request: RecipientIdentityRequest = { key, sourceId: source.id, generation: source.generation, storeGeneration: this.generation,
-        demandEpoch: this.recipientIdentityDemandEpoch, mode: this.state.host?.inboxWindow ? "window" : "legacy" };
-      this.recipientIdentityLoads.set(key, request);
-      this.recipientIdentityQueue.set(key, request);
-    }
-    this.drainRecipientIdentityReads();
-  }
-  private scheduleRecipientIdentityRefresh() {
-    clearTimeout(this.recipientIdentityRefreshTimer);
-    this.recipientIdentityRefreshTimer = undefined;
-    const active = this.recipientIdentityActive;
-    const next = Math.min(...[...this.recipientIdentityCache.entries()].flatMap(([sourceId, cached]) => {
-      const key = `${sourceId}\0${cached.generation}`;
-      return active.has(key) && !this.recipientIdentityLoads.has(key) ? [cached.checkedAt + RECIPIENT_IDENTITY_TTL_MS] : [];
-    }));
-    if (!Number.isFinite(next)) return;
-    this.recipientIdentityRefreshTimer = setTimeout(() => {
-      this.recipientIdentityRefreshTimer = undefined;
-      if (this.state.host?.inboxWindow) this.rebuildWindow();
-      else {
-        this.scheduleRecipientIdentityReads([...this.legacyRecipientDemand.values()]);
-        this.scheduleRecipientIdentityRefresh();
-      }
-    }, Math.max(1, next - Date.now()));
-  }
-  private drainRecipientIdentityReads() {
-    while (this.recipientIdentityWorkers.size < RECIPIENT_IDENTITY_CONCURRENCY && this.recipientIdentityQueue.size) {
-      const [key, request] = this.recipientIdentityQueue.entries().next().value!;
-      this.recipientIdentityQueue.delete(key);
-      const storeGeneration = request.storeGeneration;
-      if (request.demandEpoch !== this.recipientIdentityDemandEpoch || !this.recipientIdentityActive.has(key)
-        || !this.recipientSourceIsCurrent(request.sourceId, request.generation, storeGeneration)) {
-        if (this.recipientIdentityLoads.get(key) === request) this.recipientIdentityLoads.delete(key);
-        continue;
-      }
-      const signal = AbortSignal.any([this.recipientIdentityController.signal, this.controller.signal, this.applicationScope.signal]);
-      let worker!: Promise<void>;
-      worker = (async () => {
-        let identities: RecipientIdentity[] = [];
-        try {
-          const result = await this.client.sendingIdentities(request.sourceId, {}, { signal });
-          if (result.sourceId !== request.sourceId) throw new Error("Recipient identity source changed");
-          identities = result.identities.map(identity => ({ email: identity.email, isPrimary: identity.isPrimary }));
-        } catch {
-          // Recipient metadata is optional. A failed discovery leaves the column blank until the bounded cache expires.
-        }
-        if (signal.aborted || request.demandEpoch !== this.recipientIdentityDemandEpoch
-          || !this.recipientSourceIsCurrent(request.sourceId, request.generation, storeGeneration)) return;
-        const previous = this.recipientIdentityCache.get(request.sourceId);
-        this.recipientIdentityCache.set(request.sourceId, { generation: request.generation, checkedAt: Date.now(), identities });
-        if (previous?.generation !== request.generation || JSON.stringify(previous.identities) !== JSON.stringify(identities)) {
-          if (request.mode === "window") this.rebuildWindow();
-          else this.rebuild(new Set([...this.legacyRecipientDemand.entries()]
-            .filter(([, value]) => value.sourceId === request.sourceId).map(([thread]) => thread)));
-        }
-      })().finally(() => {
-        if (!this.recipientIdentityWorkers.delete(worker)) return;
-        if (this.recipientIdentityLoads.get(key) === request) this.recipientIdentityLoads.delete(key);
-        this.scheduleRecipientIdentityRefresh();
-        this.drainRecipientIdentityReads();
-      });
-      this.recipientIdentityWorkers.add(worker);
-    }
+  private scheduleRecipientIdentityReads(rows: readonly RecipientIdentitySource[]) {
+    this.recipientIdentities.update(rows, { storeGeneration: this.generation, mode: this.state.host?.inboxWindow ? "window" : "legacy",
+      signal: AbortSignal.any([this.controller.signal, this.applicationScope.signal]) });
   }
   sendingIdentities: LoadSendingIdentities = async (mailboxId, input = {}) => {
     const { source } = this.account(mailboxId);
@@ -1556,9 +1470,8 @@ export class InboxStore {
       this.clearPendingDone();
       this.retainedViews.clear(); this.windowCounts = undefined;
       this.client.clearCache();
-      this.resetRecipientIdentityDemand(); this.recipientIdentityCache.clear();
+      this.recipientIdentities.clear();
       this.legacyRecipientDemand.clear();
-      clearTimeout(this.recipientIdentityRefreshTimer); this.recipientIdentityRefreshTimer = undefined;
       clearTimeout(this.refreshTimer); clearTimeout(this.importantTimer); this.importantDeadline = Infinity;
       clearTimeout(this.aiPollTimer); clearTimeout(this.aiHoldTimer); this.aiPollPromise = undefined; this.aiHolds.clear();
       clearTimeout(this.aiRebuildTimer); this.aiRebuildTimer = undefined; this.aiRebuildThreads.clear();
@@ -1783,7 +1696,7 @@ export class InboxStore {
       for (const account of accounts) if (!same(presentation(account), presentation(previousAccounts.find(previous => previous.id === account.id)))) affectedSources.add(account.id);
       for (const box of selected) if (!same(box, this.boxes.find(previous => previous.id === box.id))) affectedSources.add(box.sourceId);
       this.sourceAccounts = accounts; this.boxes = selected;
-      this.pruneRecipientIdentities(accounts);
+      this.recipientIdentities.prune(accounts);
       if (!same(accounts, this.state.sources) || !same(selected, this.state.mailboxes)) this.publish({ sources: accounts, mailboxes: selected });
       const folderSources = new Set(events.filter(event => event.type === "account.updated" && event.accountId).map(event => event.accountId!));
       for (const id of folderSources) if (accounts.some(account => account.id === id && account.status === "connected")) {
@@ -2018,7 +1931,7 @@ export class InboxStore {
       }
       this.operations = operations;
       this.sourceAccounts = accounts; this.boxes = selected; this.labels = labels; this.summaries = summaries; this.sending = sending;
-      this.pruneRecipientIdentities(accounts);
+      this.recipientIdentities.prune(accounts);
       if (!host.inboxWindow) {
       this.messageRows = new Map([...summaries.values()].flat().map(row => [nativeKey(row.sourceId, row.id), row]));
       this.summaryFences = new Map([...this.messageRows].map(([key, row]) => [key, { epoch: flagEpoch, revision: row.revision }]));
@@ -2118,7 +2031,6 @@ export class InboxStore {
     const activeKeys = new Set(this.state.window?.keys ?? []);
     this.scheduleRecipientIdentityReads(rows.filter(row => activeKeys.has(row.key)
       && hasIncomingRecipientHeaders(retained.get(row.key)!)));
-    this.scheduleRecipientIdentityRefresh();
     const summaries = new Map<string, MailboxMessageSummary>();
     for (const row of rows) for (const summary of retained.get(row.key)!) {
       const key = nativeKey(summary.sourceId, summary.id), previous = summaries.get(key);
@@ -2147,10 +2059,10 @@ export class InboxStore {
       const ids = new Set(retained.get(row.key)!.map(summary => summary.id));
       if (detail?.exhausted && row.counts.messages === ids.size) { provenance.messagesComplete = true; provenance.actionContextComplete = row.targetsComplete; }
       const source = this.sourceAccounts.find(source => source.id === row.sourceId && source.generation === row.sourceGeneration);
-      const cachedIdentities = source && this.recipientIdentityCache.get(source.id);
-      const recipientAddress = source && cachedIdentities?.generation === source.generation
+      const identities = source && this.recipientIdentities.get(source.id, source.generation);
+      const recipientAddress = source && identities
         && provenance.messagesComplete
-        ? matchingRecipientAddress(retained.get(row.key)!, cachedIdentities.identities, source.email) : undefined;
+        ? matchingRecipientAddress(retained.get(row.key)!, identities, source.email) : undefined;
       // Whole-conversation aggregate/provenance always wins over partial projected metadata.
       const time = Number.isFinite(row.mail.receivedAt) ? calendar.format(new Date(row.mail.receivedAt!).toISOString()) : { date: row.mail.date, group: row.mail.group };
       let next: Mail = { ...row.mail, ...time, recipientAddress, messages: local?.messages.filter(message => ids.has(message.id)) ?? row.mail.messages, window: provenance,
@@ -2329,16 +2241,15 @@ export class InboxStore {
     labelNames[UNIFIED_ACCOUNT] = [...new Set(included.flatMap(id => labelNames[id] ?? []))];
     mail.push(...unifiedMail(mail, included, accounts));
     this.scheduleRecipientIdentityReads([...this.legacyRecipientDemand.values()]);
-    this.scheduleRecipientIdentityRefresh();
     for (const conversation of mail) {
       if (conversation.operationId || !conversation.sourceId || !conversation.sdkThreadId) continue;
       const source = this.sourceAccounts.find(source => source.id === conversation.sourceId);
-      const cached = this.recipientIdentityCache.get(conversation.sourceId);
+      const identities = source && this.recipientIdentities.get(source.id, source.generation);
       const rows = conversation.account === UNIFIED_ACCOUNT
         ? [...(unifiedRecipientRows.get(nativeKey(conversation.sourceId, conversation.sdkThreadId))?.values() ?? [])]
         : recipientRows.get(conversation.id) ?? [];
-      conversation.recipientAddress = source && cached?.generation === source.generation
-        ? matchingRecipientAddress(rows, cached.identities, source.email) : undefined;
+      conversation.recipientAddress = source && identities
+        ? matchingRecipientAddress(rows, identities, source.email) : undefined;
     }
     if (!onlyThreads) this.knownThreads.clear();
     const ai = this.state.ai;
@@ -2605,9 +2516,7 @@ export class InboxStore {
       if (this.account(box.id).box.revision !== box.revision) throw new Error("The sending mailbox changed. Retry to compose with its current senders.");
       const context = this.messageRows.get(nativeKey(source.id, parent));
       if (!context || context.threadId !== input.mail?.sdkThreadId || !context.memberships.some(state => state.mailboxId === box.id)) throw new Error("The selected message no longer belongs to this mailbox.");
-      const selector = box.selector;
-      const eligible = catalog.identities.filter(identity => selector.kind === "address" ? identity.email.toLowerCase() === selector.value.toLowerCase()
-        : selector.kind === "domain" ? identity.email.split("@").at(-1)?.toLowerCase() === selector.value.toLowerCase() : true);
+      const eligible = catalog.identities.filter(identity => sendingIdentityMatchesMailbox(identity.email, box.selector));
       from = senderFromRecipients(context, eligible) ?? from;
     }
     // Contact composition borrows only the sender identity, not reply threading or content.

--- a/apps/web/src/inbox.ts
+++ b/apps/web/src/inbox.ts
@@ -2581,13 +2581,26 @@ export class InboxStore {
     const { box, source } = this.account(boxId);
     if (!this.state.accounts.find(account => account.id === boxId)?.canSend) throw new Error("This mailbox cannot send messages.");
     if (input.mode && input.mode !== "new" && input.mode !== "forward" && !source.capabilities.reply) throw new Error("This source cannot send replies.");
-    if (input.mail) await this.loadThread(input.mail.id);
+    const composing = !input.mode || input.mode === "new";
+    if (input.mail && !composing) await this.loadThread(input.mail.id);
     if (input.sourceMessageId && !input.mail?.messages.some(message => message.id === input.sourceMessageId)) throw new Error("The selected message no longer belongs to this conversation.");
     const parent = input.sourceMessageId ?? input.mail?.messages.filter(message => !message.pending).at(-1)?.id;
     if (input.mail?.messages.find(message => message.id === parent)?.pending) throw new Error("Wait for the queued message to finish sending before replying to it.");
     const implicitReply = !!parent && (input.mode === "reply" || input.mode === "replyAll");
-    const raw = await this.client.createDraft({ accountId: source.id, mailboxId: box.id, ...(!implicitReply ? { from: box.defaultSender! } : {}),
-      mode: input.mode === "new" || !input.mode ? "compose" : input.mode, ...(parent ? { sourceMessageId: parent } : {}),
+    let from = box.defaultSender!;
+    if (composing && parent) {
+      const catalog = await this.sendingIdentities(box.id);
+      if (this.account(box.id).box.revision !== box.revision) throw new Error("The sending mailbox changed. Retry to compose with its current senders.");
+      const context = this.messageRows.get(nativeKey(source.id, parent));
+      if (!context || context.threadId !== input.mail?.sdkThreadId || !context.memberships.some(state => state.mailboxId === box.id)) throw new Error("The selected message no longer belongs to this mailbox.");
+      const selector = box.selector;
+      const eligible = catalog.identities.filter(identity => selector.kind === "address" ? identity.email.toLowerCase() === selector.value.toLowerCase()
+        : selector.kind === "domain" ? identity.email.split("@").at(-1)?.toLowerCase() === selector.value.toLowerCase() : true);
+      from = matchingRecipientAlias([context], eligible, source.email) ?? from;
+    }
+    // Contact composition borrows only the sender identity, not reply threading or content.
+    const raw = await this.client.createDraft({ accountId: source.id, mailboxId: box.id, ...(!implicitReply ? { from } : {}),
+      mode: input.mode === "new" || !input.mode ? "compose" : input.mode, ...(parent && !composing ? { sourceMessageId: parent } : {}),
       ...(input.subject !== undefined ? { subject: input.subject } : {}), ...(input.body !== undefined ? { bodyHtml: draftHtml(input.body), bodyText: plainText(input.body) } : {}),
       ...(input.to !== undefined ? { to: recipients(input.to) } : {}),
     }, this.requestOptions());

--- a/apps/web/src/inbox.ts
+++ b/apps/web/src/inbox.ts
@@ -16,7 +16,7 @@ import { getApplicationStorage } from "./storage";
 import { createScopedFetch } from "./application-auth";
 import { getApplicationScope } from "./application-scope";
 import { matchesSearch } from "./mail-search";
-import { hasIncomingRecipientHeaders, matchingRecipientAddress, matchingRecipientAlias } from "./recipient-alias";
+import { hasIncomingRecipientHeaders, matchingRecipientAddress, matchingRecipientAlias, type RecipientIdentity } from "./recipient-address";
 import { readHostConfiguration, readInboxViewPreferences, writeInboxViewPreferences, createAiTriageClient, type HostConfiguration, type InboxViewPreferences, createCategoryTransport, CategoryRequestError } from "./host";
 import { readSplitPreferences, writeSplitPreferences, readAttentionFeedback, recordAttentionFeedback, retractAttentionFeedback, InboxViewPreferencesError,
   type SavedSplitPreferences, type AttentionFeedback, type AttentionFeedbackTarget } from "./host";
@@ -49,8 +49,7 @@ const viewKey = (query: InboxViewQuery) => JSON.stringify(query);
 const expiredQuery = (error: unknown) => error instanceof InboxViewPreferencesError && error.code === "HOST_INBOX_QUERY_EXPIRED";
 type ThreadHistory = { contextVersion: string; summaries: MailboxMessageSummary[]; cursor: string | null; exhausted: boolean; truncated?: boolean; error?: string };
 type ThreadValidation = { row: InboxWindowRow; controller: AbortController; promise: Promise<{ summaries: MailboxMessageSummary[]; error?: string }> };
-type RecipientAliasIdentity = { email: string; isPrimary: boolean };
-type RecipientAliasRequest = { key: string; sourceId: string; generation: number; storeGeneration: number; demandEpoch: number; mode: "window" | "legacy" };
+type RecipientIdentityRequest = { key: string; sourceId: string; generation: number; storeGeneration: number; demandEpoch: number; mode: "window" | "legacy" };
 class DraftRecipientError extends Error {}
 type SendReference = { id: string; draftId: string; accountId: string; mailboxId: string };
 type Sending = { ref: SendReference; operation: Operation; draft: SdkDraft };
@@ -162,8 +161,8 @@ const MAX_ISSUES = 4;
 const RESOLVE_HOLD_MS = 10_000;
 /** A dismissed problem that recurs within this window starts hidden instead of reopening. */
 const DISMISSAL_MEMORY_MS = 5 * 60_000;
-const RECIPIENT_ALIAS_TTL_MS = 5 * 60_000;
-const RECIPIENT_ALIAS_CONCURRENCY = 4;
+const RECIPIENT_IDENTITY_TTL_MS = 5 * 60_000;
+const RECIPIENT_IDENTITY_CONCURRENCY = 4;
 /** Change-history polling cadence while the event stream is unavailable. */
 const POLL_MS = 30_000;
 const MAX_BACKOFF_MS = 60_000;
@@ -300,15 +299,15 @@ export class InboxStore {
   private bodyEpoch = 0;
   private blobInfo = new Map<string, BlobInfo>();
   private folders = new Map<string, Folder[]>();
-  private recipientAliases = new Map<string, { generation: number; checkedAt: number; identities: RecipientAliasIdentity[] }>();
-  private recipientAliasQueue = new Map<string, RecipientAliasRequest>();
-  private recipientAliasLoads = new Map<string, RecipientAliasRequest>();
-  private recipientAliasWorkers = new Set<Promise<void>>();
-  private recipientAliasActive = new Set<string>();
+  private recipientIdentityCache = new Map<string, { generation: number; checkedAt: number; identities: RecipientIdentity[] }>();
+  private recipientIdentityQueue = new Map<string, RecipientIdentityRequest>();
+  private recipientIdentityLoads = new Map<string, RecipientIdentityRequest>();
+  private recipientIdentityWorkers = new Set<Promise<void>>();
+  private recipientIdentityActive = new Set<string>();
   private legacyRecipientDemand = new Map<string, { sourceId: string; sourceGeneration: number }>();
-  private recipientAliasDemandEpoch = 0;
-  private recipientAliasController = new AbortController();
-  private recipientAliasRefreshTimer?: ReturnType<typeof setTimeout>;
+  private recipientIdentityDemandEpoch = 0;
+  private recipientIdentityController = new AbortController();
+  private recipientIdentityRefreshTimer?: ReturnType<typeof setTimeout>;
   private folderDiscovery?: Promise<void>;
   private discoveredFolders = new Set<string>();
   private labels: Label[] = [];
@@ -447,7 +446,7 @@ export class InboxStore {
   private restoreWindow(view: RetainedView): Promise<void> {
     const query = { ...this.windowQuery }, epoch = ++this.windowEpoch, generation = this.generation;
     this.windowController.abort(); this.windowController = new AbortController();
-    this.resetRecipientAliasDemand();
+    this.resetRecipientIdentityDemand();
     this.clearThreadMessagePins();
     // An aborted open or drain of the previous view must not gate this view's reconciliation.
     this.windowLoading = undefined; this.windowPaging = undefined; this.windowChanges = undefined;
@@ -715,7 +714,7 @@ export class InboxStore {
   private openWindow = (): Promise<void> => {
     const query = { ...this.windowQuery }, epoch = ++this.windowEpoch, generation = this.generation;
     this.windowController.abort(); this.windowController = new AbortController();
-    this.resetRecipientAliasDemand();
+    this.resetRecipientIdentityDemand();
     this.clearThreadMessagePins();
     this.windowPaging = undefined; this.windowChanges = undefined; this.windowReplayCheckpoint = undefined; this.windowBoundaryCursors.clear(); this.windowNewerCursor = null; this.windowLocalRemoved.clear(); this.windowRemovalFences.clear(); this.windowAutoDone = false;
     const signal = AbortSignal.any([this.windowController.signal, this.controller.signal]);
@@ -1274,23 +1273,23 @@ export class InboxStore {
     if (!box || !source) throw new Error("Select a connected mailbox first.");
     return { box, source };
   }
-  private pruneRecipientAliases(accounts: readonly Account[]) {
-    for (const [sourceId, cached] of this.recipientAliases) {
+  private pruneRecipientIdentities(accounts: readonly Account[]) {
+    for (const [sourceId, cached] of this.recipientIdentityCache) {
       const source = accounts.find(account => account.id === sourceId);
-      if (source?.status !== "connected" || source.generation !== cached.generation) this.recipientAliases.delete(sourceId);
+      if (source?.status !== "connected" || source.generation !== cached.generation) this.recipientIdentityCache.delete(sourceId);
     }
   }
-  private resetRecipientAliasDemand() {
-    this.recipientAliasDemandEpoch++;
-    this.recipientAliasController.abort(); this.recipientAliasController = new AbortController();
-    this.recipientAliasQueue.clear(); this.recipientAliasLoads.clear(); this.recipientAliasWorkers.clear(); this.recipientAliasActive.clear();
-    clearTimeout(this.recipientAliasRefreshTimer); this.recipientAliasRefreshTimer = undefined;
+  private resetRecipientIdentityDemand() {
+    this.recipientIdentityDemandEpoch++;
+    this.recipientIdentityController.abort(); this.recipientIdentityController = new AbortController();
+    this.recipientIdentityQueue.clear(); this.recipientIdentityLoads.clear(); this.recipientIdentityWorkers.clear(); this.recipientIdentityActive.clear();
+    clearTimeout(this.recipientIdentityRefreshTimer); this.recipientIdentityRefreshTimer = undefined;
   }
   private recipientSourceIsCurrent(sourceId: string, sourceGeneration: number, storeGeneration: number): boolean {
     if (storeGeneration !== this.generation || this.controller.signal.aborted || this.applicationScope.signal.aborted) return false;
     const source = this.sourceAccounts.find(account => account.id === sourceId);
     if (!this.state.host?.inboxWindow) return source?.generation === sourceGeneration && source.status === "connected"
-      && this.recipientAliasActive.has(`${sourceId}\0${sourceGeneration}`);
+      && this.recipientIdentityActive.has(`${sourceId}\0${sourceGeneration}`);
     const window = this.state.window;
     return source?.generation === sourceGeneration && source.status === "connected" && !!window
       && window.state.sources.some(value => value.sourceId === sourceId && value.generation === sourceGeneration)
@@ -1299,50 +1298,50 @@ export class InboxStore {
         return row?.sourceId === sourceId && row.sourceGeneration === sourceGeneration;
       });
   }
-  private scheduleRecipientAliases(rows: readonly { sourceId: string; sourceGeneration: number }[]) {
+  private scheduleRecipientIdentityReads(rows: readonly { sourceId: string; sourceGeneration: number }[]) {
     const now = Date.now();
-    this.recipientAliasActive = new Set(rows.map(row => `${row.sourceId}\0${row.sourceGeneration}`));
+    this.recipientIdentityActive = new Set(rows.map(row => `${row.sourceId}\0${row.sourceGeneration}`));
     for (const row of rows) {
       const source = this.sourceAccounts.find(account => account.id === row.sourceId);
       if (!source || source.status !== "connected" || source.generation !== row.sourceGeneration) continue;
-      const current = this.recipientAliases.get(source.id);
+      const current = this.recipientIdentityCache.get(source.id);
       const key = `${source.id}\0${source.generation}`;
-      if (current?.generation === source.generation && now - current.checkedAt < RECIPIENT_ALIAS_TTL_MS
-        || this.recipientAliasLoads.has(key)) continue;
-      const request: RecipientAliasRequest = { key, sourceId: source.id, generation: source.generation, storeGeneration: this.generation,
-        demandEpoch: this.recipientAliasDemandEpoch, mode: this.state.host?.inboxWindow ? "window" : "legacy" };
-      this.recipientAliasLoads.set(key, request);
-      this.recipientAliasQueue.set(key, request);
+      if (current?.generation === source.generation && now - current.checkedAt < RECIPIENT_IDENTITY_TTL_MS
+        || this.recipientIdentityLoads.has(key)) continue;
+      const request: RecipientIdentityRequest = { key, sourceId: source.id, generation: source.generation, storeGeneration: this.generation,
+        demandEpoch: this.recipientIdentityDemandEpoch, mode: this.state.host?.inboxWindow ? "window" : "legacy" };
+      this.recipientIdentityLoads.set(key, request);
+      this.recipientIdentityQueue.set(key, request);
     }
-    this.drainRecipientAliases();
+    this.drainRecipientIdentityReads();
   }
-  private scheduleRecipientAliasRefresh() {
-    clearTimeout(this.recipientAliasRefreshTimer);
-    this.recipientAliasRefreshTimer = undefined;
-    const active = this.recipientAliasActive;
-    const next = Math.min(...[...this.recipientAliases.entries()].flatMap(([sourceId, cached]) => {
+  private scheduleRecipientIdentityRefresh() {
+    clearTimeout(this.recipientIdentityRefreshTimer);
+    this.recipientIdentityRefreshTimer = undefined;
+    const active = this.recipientIdentityActive;
+    const next = Math.min(...[...this.recipientIdentityCache.entries()].flatMap(([sourceId, cached]) => {
       const key = `${sourceId}\0${cached.generation}`;
-      return active.has(key) && !this.recipientAliasLoads.has(key) ? [cached.checkedAt + RECIPIENT_ALIAS_TTL_MS] : [];
+      return active.has(key) && !this.recipientIdentityLoads.has(key) ? [cached.checkedAt + RECIPIENT_IDENTITY_TTL_MS] : [];
     }));
     if (!Number.isFinite(next)) return;
-    this.recipientAliasRefreshTimer = setTimeout(() => {
-      this.recipientAliasRefreshTimer = undefined;
+    this.recipientIdentityRefreshTimer = setTimeout(() => {
+      this.recipientIdentityRefreshTimer = undefined;
       if (this.state.host?.inboxWindow) this.rebuildWindow();
       else {
-        this.scheduleRecipientAliases([...this.legacyRecipientDemand.values()]);
-        this.scheduleRecipientAliasRefresh();
+        this.scheduleRecipientIdentityReads([...this.legacyRecipientDemand.values()]);
+        this.scheduleRecipientIdentityRefresh();
       }
     }, Math.max(1, next - Date.now()));
   }
-  private drainRecipientAliases() {
-    while (this.recipientAliasWorkers.size < RECIPIENT_ALIAS_CONCURRENCY && this.recipientAliasQueue.size) {
-      const [key, request] = this.recipientAliasQueue.entries().next().value!;
-      this.recipientAliasQueue.delete(key);
+  private drainRecipientIdentityReads() {
+    while (this.recipientIdentityWorkers.size < RECIPIENT_IDENTITY_CONCURRENCY && this.recipientIdentityQueue.size) {
+      const [key, request] = this.recipientIdentityQueue.entries().next().value!;
+      this.recipientIdentityQueue.delete(key);
       const storeGeneration = request.storeGeneration;
-      const signal = AbortSignal.any([this.recipientAliasController.signal, this.controller.signal, this.applicationScope.signal]);
+      const signal = AbortSignal.any([this.recipientIdentityController.signal, this.controller.signal, this.applicationScope.signal]);
       let worker!: Promise<void>;
       worker = (async () => {
-        let identities: RecipientAliasIdentity[] = [];
+        let identities: RecipientIdentity[] = [];
         try {
           const result = await this.client.sendingIdentities(request.sourceId, {}, { signal });
           if (result.sourceId !== request.sourceId) throw new Error("Recipient identity source changed");
@@ -1350,22 +1349,22 @@ export class InboxStore {
         } catch {
           // Recipient metadata is optional. A failed discovery leaves the column blank until the bounded cache expires.
         }
-        if (signal.aborted || request.demandEpoch !== this.recipientAliasDemandEpoch
+        if (signal.aborted || request.demandEpoch !== this.recipientIdentityDemandEpoch
           || !this.recipientSourceIsCurrent(request.sourceId, request.generation, storeGeneration)) return;
-        const previous = this.recipientAliases.get(request.sourceId);
-        this.recipientAliases.set(request.sourceId, { generation: request.generation, checkedAt: Date.now(), identities });
+        const previous = this.recipientIdentityCache.get(request.sourceId);
+        this.recipientIdentityCache.set(request.sourceId, { generation: request.generation, checkedAt: Date.now(), identities });
         if (previous?.generation !== request.generation || JSON.stringify(previous.identities) !== JSON.stringify(identities)) {
           if (request.mode === "window") this.rebuildWindow();
           else this.rebuild(new Set([...this.legacyRecipientDemand.entries()]
             .filter(([, value]) => value.sourceId === request.sourceId).map(([thread]) => thread)));
         }
       })().finally(() => {
-        if (!this.recipientAliasWorkers.delete(worker)) return;
-        if (this.recipientAliasLoads.get(key) === request) this.recipientAliasLoads.delete(key);
-        this.scheduleRecipientAliasRefresh();
-        this.drainRecipientAliases();
+        if (!this.recipientIdentityWorkers.delete(worker)) return;
+        if (this.recipientIdentityLoads.get(key) === request) this.recipientIdentityLoads.delete(key);
+        this.scheduleRecipientIdentityRefresh();
+        this.drainRecipientIdentityReads();
       });
-      this.recipientAliasWorkers.add(worker);
+      this.recipientIdentityWorkers.add(worker);
     }
   }
   sendingIdentities: LoadSendingIdentities = async (mailboxId, input = {}) => {
@@ -1544,9 +1543,9 @@ export class InboxStore {
       this.clearPendingDone();
       this.retainedViews.clear(); this.windowCounts = undefined;
       this.client.clearCache();
-      this.resetRecipientAliasDemand(); this.recipientAliases.clear();
+      this.resetRecipientIdentityDemand(); this.recipientIdentityCache.clear();
       this.legacyRecipientDemand.clear();
-      clearTimeout(this.recipientAliasRefreshTimer); this.recipientAliasRefreshTimer = undefined;
+      clearTimeout(this.recipientIdentityRefreshTimer); this.recipientIdentityRefreshTimer = undefined;
       clearTimeout(this.refreshTimer); clearTimeout(this.importantTimer); this.importantDeadline = Infinity;
       clearTimeout(this.aiPollTimer); clearTimeout(this.aiHoldTimer); this.aiPollPromise = undefined; this.aiHolds.clear();
       clearTimeout(this.aiRebuildTimer); this.aiRebuildTimer = undefined; this.aiRebuildThreads.clear();
@@ -1771,7 +1770,7 @@ export class InboxStore {
       for (const account of accounts) if (!same(presentation(account), presentation(previousAccounts.find(previous => previous.id === account.id)))) affectedSources.add(account.id);
       for (const box of selected) if (!same(box, this.boxes.find(previous => previous.id === box.id))) affectedSources.add(box.sourceId);
       this.sourceAccounts = accounts; this.boxes = selected;
-      this.pruneRecipientAliases(accounts);
+      this.pruneRecipientIdentities(accounts);
       if (!same(accounts, this.state.sources) || !same(selected, this.state.mailboxes)) this.publish({ sources: accounts, mailboxes: selected });
       const folderSources = new Set(events.filter(event => event.type === "account.updated" && event.accountId).map(event => event.accountId!));
       for (const id of folderSources) if (accounts.some(account => account.id === id && account.status === "connected")) {
@@ -2006,7 +2005,7 @@ export class InboxStore {
       }
       this.operations = operations;
       this.sourceAccounts = accounts; this.boxes = selected; this.labels = labels; this.summaries = summaries; this.sending = sending;
-      this.pruneRecipientAliases(accounts);
+      this.pruneRecipientIdentities(accounts);
       if (!host.inboxWindow) {
       this.messageRows = new Map([...summaries.values()].flat().map(row => [nativeKey(row.sourceId, row.id), row]));
       this.summaryFences = new Map([...this.messageRows].map(([key, row]) => [key, { epoch: flagEpoch, revision: row.revision }]));
@@ -2104,9 +2103,9 @@ export class InboxStore {
     const calendar = displayTimes(); this.calendarKey = calendar.key;
     const rows = [...this.windowRows.values()], retained = new Map(rows.map(row => [row.key, this.threadSummaries(row).summaries]));
     const activeKeys = new Set(this.state.window?.keys ?? []);
-    this.scheduleRecipientAliases(rows.filter(row => activeKeys.has(row.key)
+    this.scheduleRecipientIdentityReads(rows.filter(row => activeKeys.has(row.key)
       && hasIncomingRecipientHeaders(retained.get(row.key)!)));
-    this.scheduleRecipientAliasRefresh();
+    this.scheduleRecipientIdentityRefresh();
     const summaries = new Map<string, MailboxMessageSummary>();
     for (const row of rows) for (const summary of retained.get(row.key)!) {
       const key = nativeKey(summary.sourceId, summary.id), previous = summaries.get(key);
@@ -2135,13 +2134,13 @@ export class InboxStore {
       const ids = new Set(retained.get(row.key)!.map(summary => summary.id));
       if (detail?.exhausted && row.counts.messages === ids.size) { provenance.messagesComplete = true; provenance.actionContextComplete = row.targetsComplete; }
       const source = this.sourceAccounts.find(source => source.id === row.sourceId && source.generation === row.sourceGeneration);
-      const aliases = source && this.recipientAliases.get(source.id);
-      const recipientAlias = source && aliases?.generation === source.generation
+      const cachedIdentities = source && this.recipientIdentityCache.get(source.id);
+      const recipientAddress = source && cachedIdentities?.generation === source.generation
         && provenance.messagesComplete
-        ? matchingRecipientAddress(retained.get(row.key)!, aliases.identities, source.email) : undefined;
+        ? matchingRecipientAddress(retained.get(row.key)!, cachedIdentities.identities, source.email) : undefined;
       // Whole-conversation aggregate/provenance always wins over partial projected metadata.
       const time = Number.isFinite(row.mail.receivedAt) ? calendar.format(new Date(row.mail.receivedAt!).toISOString()) : { date: row.mail.date, group: row.mail.group };
-      let next: Mail = { ...row.mail, ...time, recipientAlias, messages: local?.messages.filter(message => ids.has(message.id)) ?? row.mail.messages, window: provenance,
+      let next: Mail = { ...row.mail, ...time, recipientAddress, messages: local?.messages.filter(message => ids.has(message.id)) ?? row.mail.messages, window: provenance,
         hasAttachments: row.mail.hasAttachments ?? (row.messagesComplete ? row.mail.messages.some(message => message.hasAttachments) : undefined), historyExhausted: detail?.exhausted ?? row.messagesComplete,
         historyTruncated: detail?.truncated || undefined, historyError: detail?.error };
       const overlay = row.summaries.some(summary => this.projectFlags(summary) !== summary);
@@ -2212,9 +2211,9 @@ export class InboxStore {
     const mail: Mail[] = [], labelNames: Record<string, string[]> = {};
     if (!onlyThreads) this.legacyRecipientDemand.clear();
     else for (const key of onlyThreads) this.legacyRecipientDemand.delete(key);
-    const aliasRows = new Map<string, MailboxMessageSummary[]>();
-    const unifiedAliasRows = new Map<string, Map<string, MailboxMessageSummary>>();
-    const includedAliases = new Set(this.unifiedMailboxIds());
+    const recipientRows = new Map<string, MailboxMessageSummary[]>();
+    const unifiedRecipientRows = new Map<string, Map<string, MailboxMessageSummary>>();
+    const includedRecipientMailboxes = new Set(this.unifiedMailboxIds());
     const senderHistory = new Map<string, SenderHistoryMessage>();
     const sentMessages = new Map<string, Operation>();
     for (const operation of this.operations.values()) if (operation.type === "send") {
@@ -2245,12 +2244,12 @@ export class InboxStore {
       }
       for (const [thread, rows] of groups) {
         const key = nativeKey(source.id, thread);
-        aliasRows.set(viewThreadId(box.id, thread), rows);
+        recipientRows.set(viewThreadId(box.id, thread), rows);
         if (hasIncomingRecipientHeaders(rows)) this.legacyRecipientDemand.set(key, { sourceId: source.id, sourceGeneration: source.generation });
-        if (includedAliases.has(box.id)) {
-          const combined = unifiedAliasRows.get(key) ?? new Map<string, MailboxMessageSummary>();
+        if (includedRecipientMailboxes.has(box.id)) {
+          const combined = unifiedRecipientRows.get(key) ?? new Map<string, MailboxMessageSummary>();
           for (const row of rows) if ((combined.get(row.id)?.revision ?? -1) <= row.revision) combined.set(row.id, row);
-          unifiedAliasRows.set(key, combined);
+          unifiedRecipientRows.set(key, combined);
         }
         rows.sort((a, b) => a.receivedAt.localeCompare(b.receivedAt) || a.id.localeCompare(b.id));
         const latest = rows.at(-1)!;
@@ -2316,16 +2315,16 @@ export class InboxStore {
     const included = this.unifiedMailboxIds();
     labelNames[UNIFIED_ACCOUNT] = [...new Set(included.flatMap(id => labelNames[id] ?? []))];
     mail.push(...unifiedMail(mail, included, accounts));
-    this.scheduleRecipientAliases([...this.legacyRecipientDemand.values()]);
-    this.scheduleRecipientAliasRefresh();
+    this.scheduleRecipientIdentityReads([...this.legacyRecipientDemand.values()]);
+    this.scheduleRecipientIdentityRefresh();
     for (const conversation of mail) {
       if (conversation.operationId || !conversation.sourceId || !conversation.sdkThreadId) continue;
       const source = this.sourceAccounts.find(source => source.id === conversation.sourceId);
-      const cached = this.recipientAliases.get(conversation.sourceId);
+      const cached = this.recipientIdentityCache.get(conversation.sourceId);
       const rows = conversation.account === UNIFIED_ACCOUNT
-        ? [...(unifiedAliasRows.get(nativeKey(conversation.sourceId, conversation.sdkThreadId))?.values() ?? [])]
-        : aliasRows.get(conversation.id) ?? [];
-      conversation.recipientAlias = source && cached?.generation === source.generation
+        ? [...(unifiedRecipientRows.get(nativeKey(conversation.sourceId, conversation.sdkThreadId))?.values() ?? [])]
+        : recipientRows.get(conversation.id) ?? [];
+      conversation.recipientAddress = source && cached?.generation === source.generation
         ? matchingRecipientAddress(rows, cached.identities, source.email) : undefined;
     }
     if (!onlyThreads) this.knownThreads.clear();

--- a/apps/web/src/recipient-address.ts
+++ b/apps/web/src/recipient-address.ts
@@ -1,16 +1,9 @@
-import { isIncomingRecipientFolder } from "inbox-sdk/sender-selection";
+import { isIncomingRecipientFolder, type senderFromRecipients } from "inbox-sdk/sender-selection";
+import type { SendingIdentity } from "inbox-sdk/types";
 
-type RecipientSummary = {
-  folder: string;
-  to: readonly { email: string }[];
-  cc: readonly { email: string }[];
-  deliveredTo?: readonly string[];
-};
+type RecipientSummary = Parameters<typeof senderFromRecipients>[0];
 
-export type RecipientIdentity = {
-  email: string;
-  isPrimary: boolean;
-};
+export type RecipientIdentity = Pick<SendingIdentity, "email" | "isPrimary">;
 
 /** Header recipients from drafts, sends and queued sends are not evidence of incoming delivery. */
 export function hasIncomingRecipientHeaders(messages: readonly RecipientSummary[]): boolean {

--- a/apps/web/src/recipient-address.ts
+++ b/apps/web/src/recipient-address.ts
@@ -5,14 +5,14 @@ type RecipientSummary = {
   deliveredTo?: readonly string[];
 };
 
-type RecipientIdentity = {
+export type RecipientIdentity = {
   email: string;
   isPrimary: boolean;
 };
 
 const nonIncomingFolders = new Set(["sent", "draft", "drafts", "scheduled", "outbox", "unsent", "queued"]);
 
-export const isIncomingRecipientFolder = (folder: string): boolean => !nonIncomingFolders.has(folder.toLowerCase());
+const isIncomingRecipientFolder = (folder: string): boolean => !nonIncomingFolders.has(folder.toLowerCase());
 
 /** Header recipients from drafts, sends and queued sends are not evidence of incoming delivery. */
 export function hasIncomingRecipientHeaders(messages: readonly RecipientSummary[]): boolean {
@@ -46,22 +46,24 @@ function matchRecipient(
   mode: "alias" | "address",
 ): string | undefined {
   const own = new Set(identities.filter((identity) => !identity.isPrimary).map((identity) => identity.email.toLowerCase()));
-  own.delete(primary.toLowerCase());
+  const primaryEmail = primary.toLowerCase();
+  own.delete(primaryEmail);
   const primaries = new Set(mode === "address" ? identities
-    .filter((identity) => identity.isPrimary || identity.email.toLowerCase() === primary.toLowerCase())
+    .filter((identity) => identity.isPrimary || identity.email.toLowerCase() === primaryEmail)
     .map((identity) => identity.email.toLowerCase()) : []);
   const primaryMatches = new Set<string>();
   let match: string | undefined;
   for (const message of messages) {
     if (!isIncomingRecipientFolder(message.folder)) continue;
+    const headerRecipients = [...message.to, ...message.cc].map((recipient) => recipient.email.toLowerCase());
+    const deliveredRecipients = (message.deliveredTo ?? []).map((email) => email.toLowerCase());
     if (primaries.size) {
-      for (const email of [...message.to, ...message.cc].map((recipient) => recipient.email.toLowerCase())
-        .concat((message.deliveredTo ?? []).map((email) => email.toLowerCase()))) {
+      for (const email of headerRecipients.concat(deliveredRecipients)) {
         if (primaries.has(email)) primaryMatches.add(email);
       }
     }
-    const recipients = new Set([...message.to, ...message.cc].map((recipient) => recipient.email.toLowerCase()).filter((email) => own.has(email)));
-    const delivered = new Set((message.deliveredTo ?? []).map((email) => email.toLowerCase()).filter((email) => own.has(email)));
+    const recipients = new Set(headerRecipients.filter((email) => own.has(email)));
+    const delivered = new Set(deliveredRecipients.filter((email) => own.has(email)));
     // Gmail often delivers an alias to the primary address. Preserve a unique
     // To/Cc alias, using Delivered-To only for missing or ambiguous recipients.
     for (const email of recipients.size === 1 || delivered.size === 0 ? recipients : delivered) {

--- a/apps/web/src/recipient-address.ts
+++ b/apps/web/src/recipient-address.ts
@@ -20,37 +20,18 @@ export function hasIncomingRecipientHeaders(messages: readonly RecipientSummary[
     && (message.to.length > 0 || message.cc.length > 0 || (message.deliveredTo?.length ?? 0) > 0));
 }
 
-/** Sender inference stays alias-only. Displaying a primary recipient must not change From defaults. */
-export function matchingRecipientAlias(
-  messages: readonly RecipientSummary[],
-  identities: readonly RecipientIdentity[],
-  primary: string,
-): string | undefined {
-  return matchRecipient(messages, identities, primary, "alias");
-}
-
-/** Prefer a known alias, otherwise show a uniquely matched primary address, never an assumed account. */
+/** Prefer a unique alias, otherwise a matched primary, across the conversation. Never select From here. */
 export function matchingRecipientAddress(
   messages: readonly RecipientSummary[],
   identities: readonly RecipientIdentity[],
   primary: string,
 ): string | undefined {
-  return matchRecipient(messages, identities, primary, "address");
-}
-
-/** Header hints are not authenticated delivery evidence. */
-function matchRecipient(
-  messages: readonly RecipientSummary[],
-  identities: readonly RecipientIdentity[],
-  primary: string,
-  mode: "alias" | "address",
-): string | undefined {
   const own = new Set(identities.filter((identity) => !identity.isPrimary).map((identity) => identity.email.toLowerCase()));
   const primaryEmail = primary.toLowerCase();
   own.delete(primaryEmail);
-  const primaries = new Set(mode === "address" ? identities
+  const primaries = new Set(identities
     .filter((identity) => identity.isPrimary || identity.email.toLowerCase() === primaryEmail)
-    .map((identity) => identity.email.toLowerCase()) : []);
+    .map((identity) => identity.email.toLowerCase()));
   const primaryMatches = new Set<string>();
   let match: string | undefined;
   for (const message of messages) {

--- a/apps/web/src/recipient-address.ts
+++ b/apps/web/src/recipient-address.ts
@@ -1,3 +1,5 @@
+import { isIncomingRecipientFolder } from "inbox-sdk/sender-selection";
+
 type RecipientSummary = {
   folder: string;
   to: readonly { email: string }[];
@@ -9,10 +11,6 @@ export type RecipientIdentity = {
   email: string;
   isPrimary: boolean;
 };
-
-const nonIncomingFolders = new Set(["sent", "draft", "drafts", "scheduled", "outbox", "unsent", "queued"]);
-
-const isIncomingRecipientFolder = (folder: string): boolean => !nonIncomingFolders.has(folder.toLowerCase());
 
 /** Header recipients from drafts, sends and queued sends are not evidence of incoming delivery. */
 export function hasIncomingRecipientHeaders(messages: readonly RecipientSummary[]): boolean {

--- a/apps/web/src/recipient-alias.ts
+++ b/apps/web/src/recipient-alias.ts
@@ -1,0 +1,44 @@
+type RecipientSummary = {
+  folder: string;
+  to: readonly { email: string }[];
+  cc: readonly { email: string }[];
+  deliveredTo?: readonly string[];
+};
+
+type RecipientIdentity = {
+  email: string;
+  isPrimary: boolean;
+};
+
+const nonIncomingFolders = new Set(["sent", "draft", "drafts", "scheduled", "outbox", "unsent", "queued"]);
+
+export const isIncomingRecipientFolder = (folder: string): boolean => !nonIncomingFolders.has(folder.toLowerCase());
+
+/** Header recipients from drafts, sends and queued sends are not evidence of incoming delivery. */
+export function hasIncomingRecipientHeaders(messages: readonly RecipientSummary[]): boolean {
+  return messages.some((message) => isIncomingRecipientFolder(message.folder)
+    && (message.to.length > 0 || message.cc.length > 0 || (message.deliveredTo?.length ?? 0) > 0));
+}
+
+/** Match header hints only against known aliases. This is not authenticated delivery evidence. */
+export function matchingRecipientAlias(
+  messages: readonly RecipientSummary[],
+  identities: readonly RecipientIdentity[],
+  primary: string,
+): string | undefined {
+  const own = new Set(identities.filter((identity) => !identity.isPrimary).map((identity) => identity.email.toLowerCase()));
+  own.delete(primary.toLowerCase());
+  let match: string | undefined;
+  for (const message of messages) {
+    if (!isIncomingRecipientFolder(message.folder)) continue;
+    const recipients = new Set([...message.to, ...message.cc].map((recipient) => recipient.email.toLowerCase()).filter((email) => own.has(email)));
+    const delivered = new Set((message.deliveredTo ?? []).map((email) => email.toLowerCase()).filter((email) => own.has(email)));
+    // Gmail often delivers an alias to the primary address. Preserve a unique
+    // To/Cc alias, using Delivered-To only for missing or ambiguous recipients.
+    for (const email of recipients.size === 1 || delivered.size === 0 ? recipients : delivered) {
+      if (match !== undefined && match !== email) return undefined;
+      match = email;
+    }
+  }
+  return match;
+}

--- a/apps/web/src/recipient-alias.ts
+++ b/apps/web/src/recipient-alias.ts
@@ -20,17 +20,46 @@ export function hasIncomingRecipientHeaders(messages: readonly RecipientSummary[
     && (message.to.length > 0 || message.cc.length > 0 || (message.deliveredTo?.length ?? 0) > 0));
 }
 
-/** Match header hints only against known aliases. This is not authenticated delivery evidence. */
+/** Sender inference stays alias-only. Displaying a primary recipient must not change From defaults. */
 export function matchingRecipientAlias(
   messages: readonly RecipientSummary[],
   identities: readonly RecipientIdentity[],
   primary: string,
 ): string | undefined {
+  return matchRecipient(messages, identities, primary, "alias");
+}
+
+/** Prefer a known alias, otherwise show a uniquely matched primary address, never an assumed account. */
+export function matchingRecipientAddress(
+  messages: readonly RecipientSummary[],
+  identities: readonly RecipientIdentity[],
+  primary: string,
+): string | undefined {
+  return matchRecipient(messages, identities, primary, "address");
+}
+
+/** Header hints are not authenticated delivery evidence. */
+function matchRecipient(
+  messages: readonly RecipientSummary[],
+  identities: readonly RecipientIdentity[],
+  primary: string,
+  mode: "alias" | "address",
+): string | undefined {
   const own = new Set(identities.filter((identity) => !identity.isPrimary).map((identity) => identity.email.toLowerCase()));
   own.delete(primary.toLowerCase());
+  const primaries = new Set(mode === "address" ? identities
+    .filter((identity) => identity.isPrimary || identity.email.toLowerCase() === primary.toLowerCase())
+    .map((identity) => identity.email.toLowerCase()) : []);
+  const primaryMatches = new Set<string>();
   let match: string | undefined;
   for (const message of messages) {
     if (!isIncomingRecipientFolder(message.folder)) continue;
+    if (primaries.size) {
+      for (const email of [...message.to, ...message.cc].map((recipient) => recipient.email.toLowerCase())
+        .concat((message.deliveredTo ?? []).map((email) => email.toLowerCase()))) {
+        if (primaries.has(email)) primaryMatches.add(email);
+      }
+    }
     const recipients = new Set([...message.to, ...message.cc].map((recipient) => recipient.email.toLowerCase()).filter((email) => own.has(email)));
     const delivered = new Set((message.deliveredTo ?? []).map((email) => email.toLowerCase()).filter((email) => own.has(email)));
     // Gmail often delivers an alias to the primary address. Preserve a unique
@@ -40,5 +69,5 @@ export function matchingRecipientAlias(
       match = email;
     }
   }
-  return match;
+  return match ?? (primaryMatches.size === 1 ? primaryMatches.values().next().value : undefined);
 }

--- a/apps/web/src/recipient-identities.ts
+++ b/apps/web/src/recipient-identities.ts
@@ -59,17 +59,21 @@ export class RecipientIdentityLoader {
 
   update(rows: readonly RecipientIdentitySource[], scope: DemandScope): void {
     const now = Date.now();
-    this.active = new Set(rows.map(row => sourceKey(row.sourceId, row.sourceGeneration)));
+    const demand = new Map<string, RecipientIdentitySource>();
+    for (const row of rows) {
+      const key = sourceKey(row.sourceId, row.sourceGeneration);
+      if (!demand.has(key)) demand.set(key, row);
+    }
+    this.active = new Set(demand.keys());
     // Paging may retire queued work without retiring the whole view.
     for (const [key, request] of this.queue) {
       if (this.active.has(key)) continue;
       this.queue.delete(key);
       if (this.loads.get(key) === request) this.loads.delete(key);
     }
-    for (const row of rows) {
+    for (const [key, row] of demand) {
       if (!this.options.isCurrent(row.sourceId, row.sourceGeneration, scope.storeGeneration)) continue;
       const cached = this.cache.get(row.sourceId);
-      const key = sourceKey(row.sourceId, row.sourceGeneration);
       if (cached?.generation === row.sourceGeneration && now - cached.checkedAt < IDENTITY_TTL_MS || this.loads.has(key)) continue;
       const request: IdentityRequest = { ...row, ...scope, demandEpoch: this.demandEpoch };
       this.loads.set(key, request);
@@ -82,10 +86,11 @@ export class RecipientIdentityLoader {
   private scheduleRefresh(): void {
     clearTimeout(this.refreshTimer);
     this.refreshTimer = undefined;
-    const next = Math.min(...[...this.cache.entries()].flatMap(([sourceId, cached]) => {
+    let next = Infinity;
+    for (const [sourceId, cached] of this.cache) {
       const key = sourceKey(sourceId, cached.generation);
-      return this.active.has(key) && !this.loads.has(key) ? [cached.checkedAt + IDENTITY_TTL_MS] : [];
-    }));
+      if (this.active.has(key) && !this.loads.has(key)) next = Math.min(next, cached.checkedAt + IDENTITY_TTL_MS);
+    }
     if (!Number.isFinite(next)) return;
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
@@ -117,7 +122,8 @@ export class RecipientIdentityLoader {
           || !this.options.isCurrent(request.sourceId, request.sourceGeneration, request.storeGeneration)) return;
         const previous = this.cache.get(request.sourceId);
         this.cache.set(request.sourceId, { generation: request.sourceGeneration, checkedAt: Date.now(), identities });
-        if (previous?.generation !== request.sourceGeneration || JSON.stringify(previous.identities) !== JSON.stringify(identities)) {
+        if (previous?.generation !== request.sourceGeneration || previous.identities.length !== identities.length
+          || previous.identities.some((identity, index) => identity.email !== identities[index].email || identity.isPrimary !== identities[index].isPrimary)) {
           this.options.changed(request.sourceId, request.mode);
         }
       })().finally(() => {

--- a/apps/web/src/recipient-identities.ts
+++ b/apps/web/src/recipient-identities.ts
@@ -1,0 +1,133 @@
+import type { Account, SendingIdentities } from "inbox-sdk/types";
+import type { RecipientIdentity } from "./recipient-address";
+
+export type RecipientIdentitySource = { sourceId: string; sourceGeneration: number };
+type DemandScope = { storeGeneration: number; mode: "window" | "legacy"; signal: AbortSignal };
+type IdentityRequest = RecipientIdentitySource & DemandScope & { demandEpoch: number };
+type IdentityCache = { generation: number; checkedAt: number; identities: RecipientIdentity[] };
+
+const IDENTITY_TTL_MS = 5 * 60_000;
+const IDENTITY_CONCURRENCY = 4;
+const sourceKey = (sourceId: string, generation: number) => `${sourceId}\0${generation}`;
+
+/** Owns optional recipient metadata demand, cache freshness and request lifetime, not mail projection. */
+export class RecipientIdentityLoader {
+  private cache = new Map<string, IdentityCache>();
+  private queue = new Map<string, IdentityRequest>();
+  private loads = new Map<string, IdentityRequest>();
+  private workers = new Set<Promise<void>>();
+  private active = new Set<string>();
+  private demandEpoch = 0;
+  private controller = new AbortController();
+  private refreshTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(private readonly options: {
+    load(sourceId: string, signal: AbortSignal): Promise<SendingIdentities>;
+    isCurrent(sourceId: string, sourceGeneration: number, storeGeneration: number): boolean;
+    changed(sourceId: string, mode: DemandScope["mode"]): void;
+    refresh(): void;
+  }) {}
+
+  get(sourceId: string, generation: number): readonly RecipientIdentity[] | undefined {
+    const cached = this.cache.get(sourceId);
+    return cached?.generation === generation ? cached.identities : undefined;
+  }
+
+  hasDemand(sourceId: string, generation: number): boolean {
+    return this.active.has(sourceKey(sourceId, generation));
+  }
+
+  prune(accounts: readonly Pick<Account, "id" | "generation" | "status">[]): void {
+    for (const [sourceId, cached] of this.cache) {
+      const source = accounts.find(account => account.id === sourceId);
+      if (source?.status !== "connected" || source.generation !== cached.generation) this.cache.delete(sourceId);
+    }
+  }
+
+  /** Retire a view's requests without discarding reusable source metadata. */
+  reset(): void {
+    this.demandEpoch++;
+    this.controller.abort(); this.controller = new AbortController();
+    this.queue.clear(); this.loads.clear(); this.workers.clear(); this.active.clear();
+    clearTimeout(this.refreshTimer); this.refreshTimer = undefined;
+  }
+
+  clear(): void {
+    this.reset();
+    this.cache.clear();
+  }
+
+  update(rows: readonly RecipientIdentitySource[], scope: DemandScope): void {
+    const now = Date.now();
+    this.active = new Set(rows.map(row => sourceKey(row.sourceId, row.sourceGeneration)));
+    // Paging may retire queued work without retiring the whole view.
+    for (const [key, request] of this.queue) {
+      if (this.active.has(key)) continue;
+      this.queue.delete(key);
+      if (this.loads.get(key) === request) this.loads.delete(key);
+    }
+    for (const row of rows) {
+      if (!this.options.isCurrent(row.sourceId, row.sourceGeneration, scope.storeGeneration)) continue;
+      const cached = this.cache.get(row.sourceId);
+      const key = sourceKey(row.sourceId, row.sourceGeneration);
+      if (cached?.generation === row.sourceGeneration && now - cached.checkedAt < IDENTITY_TTL_MS || this.loads.has(key)) continue;
+      const request: IdentityRequest = { ...row, ...scope, demandEpoch: this.demandEpoch };
+      this.loads.set(key, request);
+      this.queue.set(key, request);
+    }
+    this.drain();
+    this.scheduleRefresh();
+  }
+
+  private scheduleRefresh(): void {
+    clearTimeout(this.refreshTimer);
+    this.refreshTimer = undefined;
+    const next = Math.min(...[...this.cache.entries()].flatMap(([sourceId, cached]) => {
+      const key = sourceKey(sourceId, cached.generation);
+      return this.active.has(key) && !this.loads.has(key) ? [cached.checkedAt + IDENTITY_TTL_MS] : [];
+    }));
+    if (!Number.isFinite(next)) return;
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = undefined;
+      this.options.refresh();
+    }, Math.max(1, next - Date.now()));
+  }
+
+  private drain(): void {
+    while (this.workers.size < IDENTITY_CONCURRENCY && this.queue.size) {
+      const [key, request] = this.queue.entries().next().value!;
+      this.queue.delete(key);
+      if (request.demandEpoch !== this.demandEpoch || !this.active.has(key)
+        || !this.options.isCurrent(request.sourceId, request.sourceGeneration, request.storeGeneration)) {
+        if (this.loads.get(key) === request) this.loads.delete(key);
+        continue;
+      }
+      const signal = AbortSignal.any([this.controller.signal, request.signal]);
+      let worker!: Promise<void>;
+      worker = (async () => {
+        let identities: RecipientIdentity[] = [];
+        try {
+          const result = await this.options.load(request.sourceId, signal);
+          if (result.sourceId !== request.sourceId) throw new Error("Recipient identity source changed");
+          identities = result.identities.map(identity => ({ email: identity.email, isPrimary: identity.isPrimary }));
+        } catch {
+          // Optional discovery failure keeps the upstream recipient fallback until the bounded cache expires.
+        }
+        if (signal.aborted || request.demandEpoch !== this.demandEpoch
+          || !this.options.isCurrent(request.sourceId, request.sourceGeneration, request.storeGeneration)) return;
+        const previous = this.cache.get(request.sourceId);
+        this.cache.set(request.sourceId, { generation: request.sourceGeneration, checkedAt: Date.now(), identities });
+        if (previous?.generation !== request.sourceGeneration || JSON.stringify(previous.identities) !== JSON.stringify(identities)) {
+          this.options.changed(request.sourceId, request.mode);
+        }
+      })().finally(() => {
+        // A retired worker must not release a replacement request's slot or load ownership.
+        if (!this.workers.delete(worker)) return;
+        if (this.loads.get(key) === request) this.loads.delete(key);
+        this.scheduleRefresh();
+        this.drain();
+      });
+      this.workers.add(worker);
+    }
+  }
+}

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -8,7 +8,7 @@ import { classifyAttention, conversationAttention } from "../../shared/mail-atte
 import { AI_INPUT_POLICY_VERSION, AI_TRIAGE_VERSION, aiSortingStatus, type AiDecision, type AiTriageState } from "../../shared/ai-triage.ts";
 import { normalizeSplits, attentionSplit } from "../../shared/splits.ts";
 import { senderActivity, senderContact, senderConversations, senderHostname, type SenderHistoryMessage } from "../src/sender-context.ts";
-import { matchingRecipientAddress, matchingRecipientAlias } from "../src/recipient-alias.ts";
+import { matchingRecipientAddress, matchingRecipientAlias } from "../src/recipient-address.ts";
 import {
   advanceMail,
   appendOutgoing,
@@ -712,11 +712,11 @@ test("SDK-backed sending identities support bounded row aliases and preserve exp
     }) as typeof fetch;
     const store = new InboxStore(); stop = store.start();
     await until(() => store.getSnapshot().loaded);
-    await until(() => store.getSnapshot().mail.some(mail => mail.subject === "Explicit alias reply" && mail.recipientAlias === alias));
+    await until(() => store.getSnapshot().mail.some(mail => mail.subject === "Explicit alias reply" && mail.recipientAddress === alias));
     assert.ok(identityReads.length <= store.getSnapshot().accounts.length, "legacy rows share bounded per-source identity discovery");
     const primary = store.getSnapshot().accounts.find(box => box.sourceId === sourceId)!;
     for (const account of [primary.id, UNIFIED_ACCOUNT]) {
-      assert.equal(store.getSnapshot().mail.find(mail => mail.account === account && mail.subject === "Explicit primary recipient")?.recipientAlias,
+      assert.equal(store.getSnapshot().mail.find(mail => mail.account === account && mail.subject === "Explicit primary recipient")?.recipientAddress,
         nativeBox.email, "legacy individual and unified rows display the matched primary address");
     }
     const secondary = store.getSnapshot().accounts.find(box => box.sourceId === host!.store.link(host!.owner, secondBox.id)!.accountId)!;
@@ -916,8 +916,8 @@ test("MailRow separates incoming recipient identities from sent To addresses", a
   const [{ createElement }, { renderToStaticMarkup }, { default: MailRow }] = await Promise.all([
     import("react"), import("react-dom/server"), import("../src/MailRow.tsx"),
   ]);
-  const render = (recipientAlias?: string, sent = false, toAddresses?: string[], to = "Actual Recipient <actual-to@example.test>") => renderToStaticMarkup(createElement(MailRow, {
-    mail: { ...inbox, to, toAddresses, recipientAlias,
+  const render = (recipientAddress?: string, sent = false, toAddresses?: string[], to = "Actual Recipient <actual-to@example.test>") => renderToStaticMarkup(createElement(MailRow, {
+    mail: { ...inbox, to, toAddresses, recipientAddress,
       account: UNIFIED_ACCOUNT, accountEmail: "owner@example.test", mailboxNames: ["Receiving mailbox"],
       messages: [{ ...inbox.messages[0], to: "actual-to@example.test", cc: "cc-only@example.test", bcc: "private-bcc@example.test" }] },
     index: 0, highlighted: false, selected: false, sent, showSnippets: false,
@@ -3016,37 +3016,37 @@ test("demand-driven host windows bound automatic requests and render unknown tot
       assert.equal(queries, 1); assert.equal(pages.length, sizes.length > 1 ? 1 : 0, `${name}: initial response plus at most one automatic buffer`);
       assert.equal(changes.length, 0, `${name}: incomplete context does not start an index-completion poller`);
       if (name === "full") {
-        await until(() => store.getSnapshot().mail.find(mail => mail.id === row(0).key)?.recipientAlias === "notes@example.test", "the Delivered-To-only source alias appears without a body read");
-        assert.equal(store.getSnapshot().mail.find(mail => mail.id === row(2).key)?.recipientAlias, source.email,
+        await until(() => store.getSnapshot().mail.find(mail => mail.id === row(0).key)?.recipientAddress === "notes@example.test", "the Delivered-To-only source alias appears without a body read");
+        assert.equal(store.getSnapshot().mail.find(mail => mail.id === row(2).key)?.recipientAddress, source.email,
           "complete bounded-window rows display the matched primary address without a body read");
-        assert.equal(store.getSnapshot().mail.find(mail => mail.id === row(1).key)?.recipientAlias, undefined,
+        assert.equal(store.getSnapshot().mail.find(mail => mail.id === row(1).key)?.recipientAddress, undefined,
           "an incomplete conversation stays blank because an omitted message could contain another alias");
         assert.equal(identityReads, 1, "one loaded source produces one identity request, not one request per row");
         const control = store as unknown as {
-          recipientAliases: Map<string, { checkedAt: number }>;
-          recipientAliasWorkers: Set<Promise<void>>;
-          recipientAliasRefreshTimer?: ReturnType<typeof setTimeout>;
+          recipientIdentityCache: Map<string, { checkedAt: number }>;
+          recipientIdentityWorkers: Set<Promise<void>>;
+          recipientIdentityRefreshTimer?: ReturnType<typeof setTimeout>;
           rebuildWindow(): void;
-          scheduleRecipientAliases(rows: []): void;
-          scheduleRecipientAliasRefresh(): void;
+          scheduleRecipientIdentityReads(rows: []): void;
+          scheduleRecipientIdentityRefresh(): void;
         };
-        await until(() => control.recipientAliasWorkers.size === 0, "initial identity read settles");
+        await until(() => control.recipientIdentityWorkers.size === 0, "initial identity read settles");
         const cachedMail = store.getSnapshot().mail.find(mail => mail.id === row(0).key)!;
         let release!: () => void;
         identityGate = new Promise<void>(resolve => { release = resolve; });
-        control.recipientAliases.get(source.id)!.checkedAt -= 300_001;
+        control.recipientIdentityCache.get(source.id)!.checkedAt -= 300_001;
         control.rebuildWindow();
         assert.equal(identityReads, 2);
         assert.strictEqual(store.getSnapshot().mail.find(mail => mail.id === row(0).key), cachedMail, "TTL refresh retains the alias and immutable mail identity while pending");
         identityGate = undefined; release();
-        await until(() => control.recipientAliasWorkers.size === 0, "unchanged identity refresh settles");
+        await until(() => control.recipientIdentityWorkers.size === 0, "unchanged identity refresh settles");
         assert.strictEqual(store.getSnapshot().mail.find(mail => mail.id === row(0).key), cachedMail, "unchanged TTL response never blanks or replaces the mail row");
-        control.recipientAliases.get(source.id)!.checkedAt -= 300_001;
-        control.scheduleRecipientAliases([]); control.scheduleRecipientAliasRefresh();
-        assert.equal(control.recipientAliasRefreshTimer, undefined, "expired sources without eligible rows have no timer, not a 1ms rebuild loop");
+        control.recipientIdentityCache.get(source.id)!.checkedAt -= 300_001;
+        control.scheduleRecipientIdentityReads([]); control.scheduleRecipientIdentityRefresh();
+        assert.equal(control.recipientIdentityRefreshTimer, undefined, "expired sources without eligible rows have no timer, not a 1ms rebuild loop");
         await sleep(10); assert.equal(identityReads, 2);
         control.rebuildWindow();
-        await until(() => control.recipientAliasWorkers.size === 0, "eligible demand resumes refresh");
+        await until(() => control.recipientIdentityWorkers.size === 0, "eligible demand resumes refresh");
       } else assert.equal(identityReads, 0, "rows without recipient summaries do not trigger identity requests");
       // Progressing passes finish beyond the old five-request cap; stalled passes stop.
       await until(() => countRequests.length === (name === "empty" ? 1 : Number.isFinite(countsKnownAfter) ? countsKnownAfter : 5), `${name}: the count fill settles`);
@@ -3968,12 +3968,12 @@ test("demand-driven host windows bound automatic requests and render unknown tot
         assert.strictEqual(store.presentWindow(store.getSnapshot().window!), store.getSnapshot().window);
         await store.setWindowQuery(activeQuery);
         const aliasControl = store as unknown as {
-          recipientAliases: Map<string, { checkedAt: number }>;
-          recipientAliasWorkers: Set<Promise<void>>;
-          recipientAliasLoads: Map<string, unknown>;
+          recipientIdentityCache: Map<string, { checkedAt: number }>;
+          recipientIdentityWorkers: Set<Promise<void>>;
+          recipientIdentityLoads: Map<string, unknown>;
         };
-        await until(() => aliasControl.recipientAliasWorkers.size === 0, "identity metadata settles before navigation");
-        aliasControl.recipientAliases.get(source.id)!.checkedAt -= 300_001;
+        await until(() => aliasControl.recipientIdentityWorkers.size === 0, "identity metadata settles before navigation");
+        aliasControl.recipientIdentityCache.get(source.id)!.checkedAt -= 300_001;
         const releases: Array<() => void> = [];
         const beforeNavigationReads = identityReads;
         for (const folder of ["Sent", "Inbox", "Sent", "Inbox", "Sent", "Inbox"]) {
@@ -3984,11 +3984,11 @@ test("demand-driven host windows bound automatic requests and render unknown tot
         assert.ok(identitySignals.slice(-6, -1).every(signal => signal.aborted), "each retired window aborts its identity demand");
         for (const release of releases.slice(0, -1)) release();
         await sleep(0);
-        assert.equal(aliasControl.recipientAliasLoads.size, 1, "late old finalizers cannot erase the current request owner");
-        assert.equal(aliasControl.recipientAliasWorkers.size, 1);
+        assert.equal(aliasControl.recipientIdentityLoads.size, 1, "late old finalizers cannot erase the current request owner");
+        assert.equal(aliasControl.recipientIdentityWorkers.size, 1);
         identityGate = undefined; releases.at(-1)!();
-        await until(() => aliasControl.recipientAliasWorkers.size === 0, "newest window identity response settles");
-        assert.ok(Date.now() - aliasControl.recipientAliases.get(source.id)!.checkedAt < 1000, "the current response, not an obsolete window, owns the refreshed metadata");
+        await until(() => aliasControl.recipientIdentityWorkers.size === 0, "newest window identity response settles");
+        assert.ok(Date.now() - aliasControl.recipientIdentityCache.get(source.id)!.checkedAt < 1000, "the current response, not an obsolete window, owns the refreshed metadata");
         const closing = store.doneOptimistically([selected(0)]);
         const closed = assert.rejects(closing, error => error instanceof DOMException && error.name === "AbortError");
         assert.equal(store.getSnapshot().pendingDone.length, 1);

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -8,6 +8,7 @@ import { classifyAttention, conversationAttention } from "../../shared/mail-atte
 import { AI_INPUT_POLICY_VERSION, AI_TRIAGE_VERSION, aiSortingStatus, type AiDecision, type AiTriageState } from "../../shared/ai-triage.ts";
 import { normalizeSplits, attentionSplit } from "../../shared/splits.ts";
 import { senderActivity, senderContact, senderConversations, senderHostname, type SenderHistoryMessage } from "../src/sender-context.ts";
+import { matchingRecipientAlias } from "../src/recipient-alias.ts";
 import {
   advanceMail,
   appendOutgoing,
@@ -28,6 +29,42 @@ const inbox = seedMail().find(
     mail.messages.every((message) => message.email !== mail.account),
 )!;
 const deadline = "2026-10-01T12:00:00.000Z";
+
+test("recipient alias display requires one verified incoming recipient match", () => {
+  const aliases = ["notes@example.test", "billing@example.test"];
+  const row = (to: string[], cc: string[] = [], folder = "inbox", deliveredTo?: string[]) => ({ folder, deliveredTo,
+    to: to.map(email => ({ email })), cc: cc.map(email => ({ email })) });
+  const match = (rows: ReturnType<typeof row>[], known = aliases) => matchingRecipientAlias(rows, known.map(email => ({ email, isPrimary: false })), "primary@example.test");
+  assert.equal(match([row(["NOTES@example.test", "external@example.test"])]), aliases[0]);
+  assert.equal(match([row(["external@example.test"], [aliases[0]])]), aliases[0]);
+  assert.equal(match([row([aliases[0]]), row([aliases[0]])]), aliases[0]);
+  assert.equal(match([row([aliases[0]]), row(["external@example.test"], [], "sent")]), aliases[0]);
+  assert.equal(match([row([aliases[0]]), row([aliases[1]], [], "sent")]), aliases[0]);
+  assert.equal(match([row([aliases[0]], [aliases[1]])]), undefined);
+  assert.equal(match([row([aliases[0]]), row([aliases[1]])]), undefined);
+  assert.equal(match([row(["primary@example.test"])], [...aliases, "PRIMARY@example.test"]), undefined);
+  assert.equal(match([row(["external@example.test"])]), undefined);
+  assert.equal(match([row([aliases[0]])], []), undefined);
+  assert.equal(match([row([aliases[0]], [], "sent")]), undefined);
+  assert.equal(match([row([aliases[0]], [], "drafts")]), undefined);
+  assert.equal(match([row(["notes+other@example.test"])]), undefined);
+  assert.equal(match([row([])]), undefined);
+  assert.equal(match([row([], [], "inbox", ["NOTES@example.test", aliases[0]])]), aliases[0]);
+  assert.equal(match([row(["list@example.test"], [], "inbox", [aliases[1]])]), aliases[1]);
+  assert.equal(match([row([aliases[0]], [], "inbox", ["primary@example.test"])]), aliases[0]);
+  assert.equal(match([row(aliases, [], "inbox", [aliases[1]])]), aliases[1]);
+  assert.equal(match([row([], [], "inbox", aliases)]), undefined);
+  assert.equal(match([row([], [], "inbox", ["unknown@example.test"])]), undefined);
+  assert.equal(match([row([], [], "inbox", ["primary@example.test"])], [...aliases, "primary@example.test"]), undefined);
+  assert.equal(match([row([], [], "inbox", [aliases[0]]), row([], [], "inbox", [aliases[1]])]), undefined);
+  assert.equal(matchingRecipientAlias([row([], [], "inbox", ["provider-primary@example.test"])], [{ email: "provider-primary@example.test", isPrimary: true }], "different-owner@example.test"), undefined);
+  assert.equal(matchingRecipientAlias([row(["provider-primary@example.test"])], [{ email: "provider-primary@example.test", isPrimary: true }], "different-owner@example.test"), undefined);
+  for (const folder of ["scheduled", "outbox", "unsent", "queued", "SENT", "draft"]) {
+    assert.equal(match([row([aliases[0]], [], folder)]), undefined, folder);
+    assert.equal(match([row([], [], folder, [aliases[0]])]), undefined, folder);
+    assert.equal(match([row([aliases[0]]), row([aliases[1]], [], folder)]), aliases[0], folder);
+  }
+});
 
 test("guided zero snapshots all active Important work without unread, custom-split or receiving-view leaks", () => {
   const now = Date.parse(deadline);
@@ -583,7 +620,7 @@ for (const scenario of ["scope and sparse reload", "lost acknowledgements and la
   }
 });
 
-test("SDK-backed sending identities stay composer-scoped and preserve explicit draft senders", async () => {
+test("SDK-backed sending identities support bounded row aliases and preserve explicit draft senders", async () => {
   // Isolate the irreversible owner lock from the other existing SDK cases.
   if (process.env.INBOX_SENDER_TEST_CHILD !== "1") {
     const result = await new Promise<{ code: number | null; output: string }>((resolve, reject) => {
@@ -652,14 +689,15 @@ test("SDK-backed sending identities stay composer-scoped and preserve explicit d
     }) as typeof fetch;
     const store = new InboxStore(); stop = store.start();
     await until(() => store.getSnapshot().loaded);
-    assert.equal(identityReads.length, 0, "inbox bootstrap never discovers sending identities");
+    await until(() => store.getSnapshot().mail.some(mail => mail.subject === "Explicit alias reply" && mail.recipientAlias === alias));
+    assert.ok(identityReads.length <= store.getSnapshot().accounts.length, "legacy rows share bounded per-source identity discovery");
     const primary = store.getSnapshot().accounts.find(box => box.sourceId === sourceId)!;
     const secondary = store.getSnapshot().accounts.find(box => box.sourceId === host!.store.link(host!.owner, secondBox.id)!.accountId)!;
     assert.equal(primary.sourceGeneration, (await host.inbox.account(host.owner, sourceId)).generation);
     const values = await store.sendingIdentities(primary.id);
     assert.equal(values.sourceId, sourceId);
     assert.ok(values.identities.some(identity => identity.email === alias));
-    assert.ok(identityReads.every(url => url.pathname === `/v1/accounts/${sourceId}/sending-identities`), "only the active composer's source is read");
+    assert.equal(identityReads.at(-1)!.pathname, `/v1/accounts/${sourceId}/sending-identities`, "composer reads its own source");
     const beforeFailure = identityReads.length;
     failIdentity = true;
     await assert.rejects(store.sendingIdentities(primary.id, { refresh: true }), error => error instanceof ApiError && error.code === "PROVIDER_UNAVAILABLE");
@@ -819,10 +857,10 @@ test("SDK-backed sending identities stay composer-scoped and preserve explicit d
   }
 });
 
-test("MailRow renders actual To recipients without mailbox or Bcc substitution", async () => {
+test("MailRow renders only the bare verified recipient alias", async () => {
   if (!process.versions.bun) {
     const result = await new Promise<{ code: number | null; output: string }>((resolve, reject) => {
-      const child = spawn("bun", ["--no-env-file", "test", import.meta.filename, "--test-name-pattern", "MailRow renders actual To"], {
+      const child = spawn("bun", ["--no-env-file", "test", import.meta.filename, "--test-name-pattern", "MailRow renders only"], {
         env: { ...process.env, INBOX_TEST_LIVE: "false" }, stdio: ["ignore", "pipe", "pipe"],
       });
       let output = "";
@@ -834,27 +872,18 @@ test("MailRow renders actual To recipients without mailbox or Bcc substitution",
   const [{ createElement }, { renderToStaticMarkup }, { default: MailRow }] = await Promise.all([
     import("react"), import("react-dom/server"), import("../src/MailRow.tsx"),
   ]);
-  const render = (to: string, sent = false, unified = false, toAddresses?: string[]) => renderToStaticMarkup(createElement(MailRow, {
-    mail: { ...inbox, to, toAddresses, account: unified ? UNIFIED_ACCOUNT : inbox.account, accountEmail: "owner@example.test",
-      mailboxNames: unified ? ["Receiving mailbox"] : undefined,
-      messages: [{ ...inbox.messages[0], to, cc: "cc-only@example.test", bcc: "private-bcc@example.test" }] },
-    index: 0, highlighted: false, selected: false, sent, showSnippets: false,
+  const render = (recipientAlias?: string) => renderToStaticMarkup(createElement(MailRow, {
+    mail: { ...inbox, to: "actual-to@example.test", toAddresses: ["actual-to@example.test"], recipientAlias,
+      account: UNIFIED_ACCOUNT, accountEmail: "owner@example.test", mailboxNames: ["Receiving mailbox"],
+      messages: [{ ...inbox.messages[0], to: "actual-to@example.test", cc: "cc-only@example.test", bcc: "private-bcc@example.test" }] },
+    index: 0, highlighted: false, selected: false, sent: false, showSnippets: false,
   }));
-  const alias = render("Project <project@example.test>");
-  assert.match(alias, /To: Project &lt;project@example.test&gt;/);
-  assert.match(alias, /title="To: Project &lt;project@example.test&gt;"/);
-  const projectedAlias = render("Project <project@example.test>", false, false, ["project@example.test"]);
-  assert.match(projectedAlias, />To: project@example.test<\/span>/);
-  assert.match(projectedAlias, /title="To: Project &lt;project@example.test&gt;"/);
-  const multiple = render("first@example.test, second@example.test", false, true);
-  assert.match(multiple, /To: first@example.test, second@example.test/);
-  assert.match(render("recipient@example.test", true), /To: recipient@example.test/, "sent rows use the real To too");
-  const absent = render("");
-  assert.match(absent, /No To recipients/);
-  assert.match(render("owner@example.test", false, true, []), /No To recipients/, "an authoritative empty To never falls back to an ownership address");
-  for (const html of [alias, projectedAlias, multiple, absent, render("", true, true), render("owner@example.test", false, true, [])]) {
-    assert.doesNotMatch(html, /private-bcc@example.test|cc-only@example.test|owner@example.test/);
-  }
+  const alias = render("notes@example.test");
+  assert.match(alias, /class="row-recipients" role="cell" title="notes@example.test">notes@example.test<\/span>/);
+  assert.doesNotMatch(alias, />To:|No To recipients/);
+  const blank = render();
+  assert.match(blank, /class="row-recipients" role="cell"><\/span>/);
+  for (const html of [alias, blank]) assert.doesNotMatch(html, /actual-to@example.test|private-bcc@example.test|cc-only@example.test|owner@example.test/);
 });
 test("SDK-backed optimistic flags retain conditional intent through latency, failures and overlapping views", async () => {
   // The ordinary web runner is Node; the actual SDK intentionally uses
@@ -2818,6 +2847,9 @@ test("demand-driven host windows bound automatic requests and render unknown tot
       const pages: PageInput[] = [], changes: ChangesInput[] = [], querySignals: AbortSignal[] = [], published: number[] = [], mismatchedCheckpoints: number[] = [];
       const captures: Array<{ path: string; id: string; account: string; queryId?: string }> = [];
       let queries = 0, revision = 1, holdQuery = false, heldQuery = false, stream: ReadableStreamDefaultController<Uint8Array> | undefined;
+      let identityReads = 0;
+      let identityGate: Promise<void> | undefined;
+      const identitySignals: AbortSignal[] = [];
       // The host count pager is resumable: unknown until its bounded passes finish, then exact.
       const countRequests: string[] = [], countsKnownAfter = name === "sparse" ? 8 : Infinity;
       const knownTotals: Page["totals"] = { conversations: 6, messages: 6, inbox: 7, splits: { Important: 7, Other: 0 }, folders: { Inbox: 7 }, holding: false };
@@ -2839,10 +2871,20 @@ test("demand-driven host windows bound automatic requests and render unknown tot
       };
       const row = (index: number): Row => {
         const id = `${box.id}:thread-${index}`, messageId = `message-${index}`;
+        const summary: import("inbox-sdk/types").MailboxMessageSummary = {
+          id: messageId, accountId: source.id, sourceId: source.id, threadId: `thread-${index}`, revision: 1,
+          from: { name: "Fictional sender", email: "sender@example.test" },
+          to: index === 0 ? [] : [{ name: "Notes", email: "notes@example.test" }], cc: [], deliveredTo: index === 0 ? ["notes@example.test"] : undefined,
+          subject: `Fictional page row ${index}`, preview: "Bounded alias row.",
+          receivedAt: new Date(Date.parse(deadline) - index * 1000).toISOString(), isRead: false, isStarred: false, folder: "inbox",
+          folderIds: [], labelIds: [], hasAttachments: false,
+          memberships: [{ mailboxId: box.id, messageId, revision: 1, done: false, snoozedUntil: null }],
+        };
         return { key: id, sourceId: source.id, threadId: `thread-${index}`, sourceGeneration: 1, revision: 1, pageCursor: `row-${index}`,
           mail: { ...inbox, id, account: box.id, mailboxId: box.id, sourceId: source.id, sourceGeneration: source.generation, sdkThreadId: `thread-${index}`, subject: `Fictional page row ${index}`,
             receivedAt: Date.parse(deadline) - index * 1000, folder: "Inbox", locations: ["Inbox"], messages: [{ ...inbox.messages[0], id: messageId, body: "", loaded: false }] },
-          summaries: [], messagesComplete: false, counts: { messages: 1, memberships: 1, unread: 1, done: 0, snoozed: 0 },
+          summaries: name === "full" && index <= 1 ? [summary] : [], messagesComplete: name === "full" && index === 0,
+          counts: { messages: 1, memberships: 1, unread: 1, done: 0, snoozed: 0 },
           targets: [{ mailboxId: box.id, messageId, revision: 1 }], targetsComplete: true, actionContextComplete: false, contextVersion: `context-${index}` };
       };
       const page = (index: number): Page => ({ state: state(), totals, rows: Array.from({ length: sizes[index] ?? 0 }, (_, i) => row(index * 100 + i)),
@@ -2850,6 +2892,15 @@ test("demand-driven host windows bound automatic requests and render unknown tot
       globalThis.fetch = (async (input, init) => {
         const url = new URL(input instanceof Request ? input.url : String(input), location.origin);
         if (url.pathname === "/v1/accounts") return Response.json([source]);
+        if (url.pathname === `/v1/accounts/${source.id}/sending-identities`) {
+          identityReads++;
+          identitySignals.push(init!.signal!);
+          if (identityGate) await identityGate; // Intentionally ignores abort: stale finalizers must not own new demand.
+          return Response.json({ sourceId: source.id, checkedAt: new Date().toISOString(), identities: [
+            { email: source.email, isPrimary: true, isDefault: true },
+            { email: "notes@example.test", isPrimary: false, isDefault: false },
+          ] });
+        }
         if (url.pathname === "/v1/mailboxes") return Response.json([box]);
         if (url.pathname === "/v1/changes") return Response.json({ state: "fictional-state", events: [], hasMore: false, resetRequired: false });
         if (["/v1/labels", "/v1/drafts", `/v1/accounts/${source.id}/folders`].includes(url.pathname)) return Response.json([]);
@@ -2912,6 +2963,37 @@ test("demand-driven host windows bound automatic requests and render unknown tot
       await sleep(650);
       assert.equal(queries, 1); assert.equal(pages.length, sizes.length > 1 ? 1 : 0, `${name}: initial response plus at most one automatic buffer`);
       assert.equal(changes.length, 0, `${name}: incomplete context does not start an index-completion poller`);
+      if (name === "full") {
+        await until(() => store.getSnapshot().mail.find(mail => mail.id === row(0).key)?.recipientAlias === "notes@example.test", "the Delivered-To-only source alias appears without a body read");
+        assert.equal(store.getSnapshot().mail.find(mail => mail.id === row(1).key)?.recipientAlias, undefined,
+          "an incomplete conversation stays blank because an omitted message could contain another alias");
+        assert.equal(identityReads, 1, "one loaded source produces one identity request, not one request per row");
+        const control = store as unknown as {
+          recipientAliases: Map<string, { checkedAt: number }>;
+          recipientAliasWorkers: Set<Promise<void>>;
+          recipientAliasRefreshTimer?: ReturnType<typeof setTimeout>;
+          rebuildWindow(): void;
+          scheduleRecipientAliases(rows: []): void;
+          scheduleRecipientAliasRefresh(): void;
+        };
+        await until(() => control.recipientAliasWorkers.size === 0, "initial identity read settles");
+        const cachedMail = store.getSnapshot().mail.find(mail => mail.id === row(0).key)!;
+        let release!: () => void;
+        identityGate = new Promise<void>(resolve => { release = resolve; });
+        control.recipientAliases.get(source.id)!.checkedAt -= 300_001;
+        control.rebuildWindow();
+        assert.equal(identityReads, 2);
+        assert.strictEqual(store.getSnapshot().mail.find(mail => mail.id === row(0).key), cachedMail, "TTL refresh retains the alias and immutable mail identity while pending");
+        identityGate = undefined; release();
+        await until(() => control.recipientAliasWorkers.size === 0, "unchanged identity refresh settles");
+        assert.strictEqual(store.getSnapshot().mail.find(mail => mail.id === row(0).key), cachedMail, "unchanged TTL response never blanks or replaces the mail row");
+        control.recipientAliases.get(source.id)!.checkedAt -= 300_001;
+        control.scheduleRecipientAliases([]); control.scheduleRecipientAliasRefresh();
+        assert.equal(control.recipientAliasRefreshTimer, undefined, "expired sources without eligible rows have no timer, not a 1ms rebuild loop");
+        await sleep(10); assert.equal(identityReads, 2);
+        control.rebuildWindow();
+        await until(() => control.recipientAliasWorkers.size === 0, "eligible demand resumes refresh");
+      } else assert.equal(identityReads, 0, "rows without recipient summaries do not trigger identity requests");
       // Progressing passes finish beyond the old five-request cap; stalled passes stop.
       await until(() => countRequests.length === (name === "empty" ? 1 : Number.isFinite(countsKnownAfter) ? countsKnownAfter : 5), `${name}: the count fill settles`);
       await sleep(120); assert.equal(countRequests.length, (name === "empty" ? 1 : Number.isFinite(countsKnownAfter) ? countsKnownAfter : 5), `${name}: a fill stops at completion or lack of progress`);
@@ -3831,6 +3913,28 @@ test("demand-driven host windows bound automatic requests and render unknown tot
         await assert.rejects(store.doneOptimistically([captured]), /only available in the Inbox/);
         assert.strictEqual(store.presentWindow(store.getSnapshot().window!), store.getSnapshot().window);
         await store.setWindowQuery(activeQuery);
+        const aliasControl = store as unknown as {
+          recipientAliases: Map<string, { checkedAt: number }>;
+          recipientAliasWorkers: Set<Promise<void>>;
+          recipientAliasLoads: Map<string, unknown>;
+        };
+        await until(() => aliasControl.recipientAliasWorkers.size === 0, "identity metadata settles before navigation");
+        aliasControl.recipientAliases.get(source.id)!.checkedAt -= 300_001;
+        const releases: Array<() => void> = [];
+        const beforeNavigationReads = identityReads;
+        for (const folder of ["Sent", "Inbox", "Sent", "Inbox", "Sent", "Inbox"]) {
+          identityGate = new Promise<void>(resolve => { releases.push(resolve); });
+          await store.setWindowQuery({ ...activeQuery, folder });
+        }
+        assert.equal(identityReads, beforeNavigationReads + 6, "more cancelled windows than the worker limit cannot starve the new window's identity read");
+        assert.ok(identitySignals.slice(-6, -1).every(signal => signal.aborted), "each retired window aborts its identity demand");
+        for (const release of releases.slice(0, -1)) release();
+        await sleep(0);
+        assert.equal(aliasControl.recipientAliasLoads.size, 1, "late old finalizers cannot erase the current request owner");
+        assert.equal(aliasControl.recipientAliasWorkers.size, 1);
+        identityGate = undefined; releases.at(-1)!();
+        await until(() => aliasControl.recipientAliasWorkers.size === 0, "newest window identity response settles");
+        assert.ok(Date.now() - aliasControl.recipientAliases.get(source.id)!.checkedAt < 1000, "the current response, not an obsolete window, owns the refreshed metadata");
         const closing = store.doneOptimistically([selected(0)]);
         const closed = assert.rejects(closing, error => error instanceof DOMException && error.name === "AbortError");
         assert.equal(store.getSnapshot().pendingDone.length, 1);

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -3080,6 +3080,59 @@ test("demand-driven host windows bound automatic requests and render unknown tot
         await sleep(10); assert.equal(identityReads, 2);
         control.rebuildWindow();
         await until(() => control.recipientIdentityWorkers.size === 0, "eligible demand resumes refresh");
+        // Exercise the real queue with more sources than worker slots, in both projection modes.
+        for (const inboxWindow of [false, true]) {
+          const queuedStore = new InboxStore();
+          const queued = queuedStore as unknown as {
+            sourceAccounts: typeof source[];
+            state: ReturnType<InboxStore["getSnapshot"]>;
+            windowRows: Map<string, Row>;
+            recipientIdentityWorkers: Set<Promise<void>>;
+            scheduleRecipientIdentityReads(rows: { sourceId: string; sourceGeneration: number }[]): void;
+            resetRecipientIdentityDemand(): void;
+          };
+          const sources = Array.from({ length: 6 }, (_, index) => ({ ...source, id: `queued-source-${index}` }));
+          const demand = sources.map(account => ({ sourceId: account.id, sourceGeneration: account.generation }));
+          queued.sourceAccounts = sources;
+          queued.state = { ...store.getSnapshot(), host: { ...store.getSnapshot().host!, inboxWindow },
+            window: { ...store.getSnapshot().window!, keys: sources.map(account => account.id),
+              state: { ...store.getSnapshot().window!.state, sources: sources.map(account => ({ sourceId: account.id, generation: account.generation })) } } };
+          queued.windowRows = new Map(sources.map(account => [account.id, { ...row(0), key: account.id, sourceId: account.id }]));
+          const reads: string[] = [], releases: Array<() => void> = [];
+          queuedStore.client.sendingIdentities = async sourceId => {
+            reads.push(sourceId);
+            await new Promise<void>(resolve => { releases.push(resolve); });
+            return { sourceId, checkedAt: new Date().toISOString(), identities: [] };
+          };
+          try {
+            queued.scheduleRecipientIdentityReads(demand);
+            assert.equal(reads.length, 4, "identity reads respect the worker bound");
+            queued.state.window = { ...queued.state.window!, keys: [] };
+            queued.scheduleRecipientIdentityReads([]);
+            for (const release of releases) release();
+            await sleep(0);
+            assert.equal(reads.length, 4, "withdrawn queued demand never starts a request when a worker finishes");
+            assert.equal(queued.recipientIdentityWorkers.size, 0);
+            queued.state.window = { ...queued.state.window!, keys: sources.map(account => account.id) };
+            queued.scheduleRecipientIdentityReads(demand.slice(4));
+            assert.deepEqual(reads.slice(4), sources.slice(4).map(account => account.id), "withdrawn sources can be requested again without stale load ownership");
+            queued.resetRecipientIdentityDemand();
+            for (const release of releases) release();
+            await sleep(0);
+            reads.length = 0; releases.length = 0;
+            queued.scheduleRecipientIdentityReads(demand);
+            assert.equal(reads.length, 4);
+            // Source validity may change while queued, without another demand scheduling pass.
+            queued.sourceAccounts = sources.map((account, index) => index === 4
+              ? { ...account, generation: account.generation + 1 } : { ...account, status: "disconnected" });
+            for (const release of releases) release();
+            await sleep(0);
+            assert.equal(reads.length, 4, "dispatch rechecks source generations and connection status before IO");
+          } finally {
+            queued.resetRecipientIdentityDemand();
+            for (const release of releases) release();
+          }
+        }
       } else assert.equal(identityReads, 0, "rows without recipient summaries do not trigger identity requests");
       // Progressing passes finish beyond the old five-request cap; stalled passes stop.
       await until(() => countRequests.length === (name === "empty" ? 1 : Number.isFinite(countsKnownAfter) ? countsKnownAfter : 5), `${name}: the count fill settles`);

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -8,7 +8,8 @@ import { classifyAttention, conversationAttention } from "../../shared/mail-atte
 import { AI_INPUT_POLICY_VERSION, AI_TRIAGE_VERSION, aiSortingStatus, type AiDecision, type AiTriageState } from "../../shared/ai-triage.ts";
 import { normalizeSplits, attentionSplit } from "../../shared/splits.ts";
 import { senderActivity, senderContact, senderConversations, senderHostname, type SenderHistoryMessage } from "../src/sender-context.ts";
-import { matchingRecipientAddress } from "../src/recipient-address.ts";
+import { hasIncomingRecipientHeaders, matchingRecipientAddress } from "../src/recipient-address.ts";
+import { senderFromRecipients } from "inbox-sdk/sender-selection";
 import {
   advanceMail,
   appendOutgoing,
@@ -82,7 +83,13 @@ test("recipient alias display requires one verified incoming recipient match", (
   assert.equal(matchingRecipientAddress([row(["provider-primary@example.test"])], [{ email: "provider-primary@example.test", isPrimary: true }], primary), "provider-primary@example.test");
   for (const folder of ["sent", "drafts", "scheduled", "outbox", "unsent", "queued", "SENT", "draft"]) {
     assert.equal(display([row([primary], [], folder, [primary])]), undefined, folder);
+    const outgoing = row([aliases[0]], [], folder, [aliases[0]]);
+    assert.equal(hasIncomingRecipientHeaders([outgoing]), false, `${folder}: no discovery demand from outgoing mail`);
+    assert.equal(senderFromRecipients(outgoing, identities), undefined, `${folder}: no inferred recipient sender from outgoing mail`);
   }
+  const archived = row([aliases[0]], [], "Archive");
+  assert.equal(hasIncomingRecipientHeaders([archived]), true);
+  assert.equal(senderFromRecipients(archived, identities), aliases[0]);
 });
 
 test("guided zero snapshots all active Important work without unread, custom-split or receiving-view leaks", () => {
@@ -774,6 +781,13 @@ test("SDK-backed sending identities support bounded row aliases and preserve exp
       assert.ok(groups.find(group => group.account.id === secondary.id)!.identities.some(identity => identity.email === secondBox.aliases[0]), "all finite aliases from other sources are offered");
       const domainOnly = sendingAddressGroups([domainBox], { [domainBox.id]: sourceCatalog }, domainBox.id);
       assert.deepEqual(domainOnly[0].identities.map(identity => identity.email), [primary.email, alias], "domain views exclude source aliases outside their authorized receiving domain");
+      const mixedCase = [{ email: alias.toUpperCase() }, { email: `other@sub.${domainBox.selectorValue}` }];
+      assert.deepEqual(sendingAddressGroups([domainBox], { [domainBox.id]: mixedCase }, domainBox.id)[0].identities.map(identity => identity.email),
+        [alias.toUpperCase()], "domain matching ignores case, preserves the chosen address and excludes subdomains");
+      assert.deepEqual(sendingAddressGroups([{ ...addressBox, selectorValue: undefined }], { [addressBox.id]: mixedCase }, addressBox.id)[0].identities.map(identity => identity.email),
+        [alias.toUpperCase()], "an address view falls back to its mailbox email without changing identity casing");
+      assert.deepEqual(sendingAddressGroups([{ ...domainBox, selectorValue: undefined }], { [domainBox.id]: mixedCase }, domainBox.id), [],
+        "a missing domain selector cannot offer another source identity");
       const readOnly = { ...secondary, id: "read-only-mailbox", email: "read-only@example.test", canSend: false };
       const renderComposer = (draft: Draft) => {
         fromControl = undefined; renderedOptions.length = 0;
@@ -3059,30 +3073,32 @@ test("demand-driven host windows bound automatic requests and render unknown tot
           "an incomplete conversation stays blank because an omitted message could contain another alias");
         assert.equal(identityReads, 1, "one loaded source produces one identity request, not one request per row");
         const control = store as unknown as {
-          recipientIdentityCache: Map<string, { checkedAt: number }>;
-          recipientIdentityWorkers: Set<Promise<void>>;
-          recipientIdentityRefreshTimer?: ReturnType<typeof setTimeout>;
+          recipientIdentities: {
+            cache: Map<string, { checkedAt: number }>;
+            workers: Set<Promise<void>>;
+            refreshTimer?: ReturnType<typeof setTimeout>;
+          };
           rebuildWindow(): void;
           scheduleRecipientIdentityReads(rows: []): void;
-          scheduleRecipientIdentityRefresh(): void;
         };
-        await until(() => control.recipientIdentityWorkers.size === 0, "initial identity read settles");
+        const identityLoader = control.recipientIdentities;
+        await until(() => identityLoader.workers.size === 0, "initial identity read settles");
         const cachedMail = store.getSnapshot().mail.find(mail => mail.id === row(0).key)!;
         let release!: () => void;
         identityGate = new Promise<void>(resolve => { release = resolve; });
-        control.recipientIdentityCache.get(source.id)!.checkedAt -= 300_001;
+        identityLoader.cache.get(source.id)!.checkedAt -= 300_001;
         control.rebuildWindow();
         assert.equal(identityReads, 2);
         assert.strictEqual(store.getSnapshot().mail.find(mail => mail.id === row(0).key), cachedMail, "TTL refresh retains the alias and immutable mail identity while pending");
         identityGate = undefined; release();
-        await until(() => control.recipientIdentityWorkers.size === 0, "unchanged identity refresh settles");
+        await until(() => identityLoader.workers.size === 0, "unchanged identity refresh settles");
         assert.strictEqual(store.getSnapshot().mail.find(mail => mail.id === row(0).key), cachedMail, "unchanged TTL response never blanks or replaces the mail row");
-        control.recipientIdentityCache.get(source.id)!.checkedAt -= 300_001;
-        control.scheduleRecipientIdentityReads([]); control.scheduleRecipientIdentityRefresh();
-        assert.equal(control.recipientIdentityRefreshTimer, undefined, "expired sources without eligible rows have no timer, not a 1ms rebuild loop");
+        identityLoader.cache.get(source.id)!.checkedAt -= 300_001;
+        control.scheduleRecipientIdentityReads([]);
+        assert.equal(identityLoader.refreshTimer, undefined, "expired sources without eligible rows have no timer, not a 1ms rebuild loop");
         await sleep(10); assert.equal(identityReads, 2);
         control.rebuildWindow();
-        await until(() => control.recipientIdentityWorkers.size === 0, "eligible demand resumes refresh");
+        await until(() => identityLoader.workers.size === 0, "eligible demand resumes refresh");
         // Exercise the real queue with more sources than worker slots, in both projection modes.
         for (const inboxWindow of [false, true]) {
           const queuedStore = new InboxStore();
@@ -3090,9 +3106,8 @@ test("demand-driven host windows bound automatic requests and render unknown tot
             sourceAccounts: typeof source[];
             state: ReturnType<InboxStore["getSnapshot"]>;
             windowRows: Map<string, Row>;
-            recipientIdentityWorkers: Set<Promise<void>>;
+            recipientIdentities: { workers: Set<Promise<void>>; reset(): void };
             scheduleRecipientIdentityReads(rows: { sourceId: string; sourceGeneration: number }[]): void;
-            resetRecipientIdentityDemand(): void;
           };
           const sources = Array.from({ length: 6 }, (_, index) => ({ ...source, id: `queued-source-${index}` }));
           const demand = sources.map(account => ({ sourceId: account.id, sourceGeneration: account.generation }));
@@ -3115,11 +3130,11 @@ test("demand-driven host windows bound automatic requests and render unknown tot
             for (const release of releases) release();
             await sleep(0);
             assert.equal(reads.length, 4, "withdrawn queued demand never starts a request when a worker finishes");
-            assert.equal(queued.recipientIdentityWorkers.size, 0);
+            assert.equal(queued.recipientIdentities.workers.size, 0);
             queued.state.window = { ...queued.state.window!, keys: sources.map(account => account.id) };
             queued.scheduleRecipientIdentityReads(demand.slice(4));
             assert.deepEqual(reads.slice(4), sources.slice(4).map(account => account.id), "withdrawn sources can be requested again without stale load ownership");
-            queued.resetRecipientIdentityDemand();
+            queued.recipientIdentities.reset();
             for (const release of releases) release();
             await sleep(0);
             reads.length = 0; releases.length = 0;
@@ -3132,7 +3147,7 @@ test("demand-driven host windows bound automatic requests and render unknown tot
             await sleep(0);
             assert.equal(reads.length, 4, "dispatch rechecks source generations and connection status before IO");
           } finally {
-            queued.resetRecipientIdentityDemand();
+            queued.recipientIdentities.reset();
             for (const release of releases) release();
           }
         }
@@ -4057,12 +4072,15 @@ test("demand-driven host windows bound automatic requests and render unknown tot
         assert.strictEqual(store.presentWindow(store.getSnapshot().window!), store.getSnapshot().window);
         await store.setWindowQuery(activeQuery);
         const aliasControl = store as unknown as {
-          recipientIdentityCache: Map<string, { checkedAt: number }>;
-          recipientIdentityWorkers: Set<Promise<void>>;
-          recipientIdentityLoads: Map<string, unknown>;
+          recipientIdentities: {
+            cache: Map<string, { checkedAt: number }>;
+            workers: Set<Promise<void>>;
+            loads: Map<string, unknown>;
+          };
         };
-        await until(() => aliasControl.recipientIdentityWorkers.size === 0, "identity metadata settles before navigation");
-        aliasControl.recipientIdentityCache.get(source.id)!.checkedAt -= 300_001;
+        const aliasLoader = aliasControl.recipientIdentities;
+        await until(() => aliasLoader.workers.size === 0, "identity metadata settles before navigation");
+        aliasLoader.cache.get(source.id)!.checkedAt -= 300_001;
         const releases: Array<() => void> = [];
         const beforeNavigationReads = identityReads;
         for (const folder of ["Sent", "Inbox", "Sent", "Inbox", "Sent", "Inbox"]) {
@@ -4073,11 +4091,11 @@ test("demand-driven host windows bound automatic requests and render unknown tot
         assert.ok(identitySignals.slice(-6, -1).every(signal => signal.aborted), "each retired window aborts its identity demand");
         for (const release of releases.slice(0, -1)) release();
         await sleep(0);
-        assert.equal(aliasControl.recipientIdentityLoads.size, 1, "late old finalizers cannot erase the current request owner");
-        assert.equal(aliasControl.recipientIdentityWorkers.size, 1);
+        assert.equal(aliasLoader.loads.size, 1, "late old finalizers cannot erase the current request owner");
+        assert.equal(aliasLoader.workers.size, 1);
         identityGate = undefined; releases.at(-1)!();
-        await until(() => aliasControl.recipientIdentityWorkers.size === 0, "newest window identity response settles");
-        assert.ok(Date.now() - aliasControl.recipientIdentityCache.get(source.id)!.checkedAt < 1000, "the current response, not an obsolete window, owns the refreshed metadata");
+        await until(() => aliasLoader.workers.size === 0, "newest window identity response settles");
+        assert.ok(Date.now() - aliasLoader.cache.get(source.id)!.checkedAt < 1000, "the current response, not an obsolete window, owns the refreshed metadata");
         const closing = store.doneOptimistically([selected(0)]);
         const closed = assert.rejects(closing, error => error instanceof DOMException && error.name === "AbortError");
         assert.equal(store.getSnapshot().pendingDone.length, 1);

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -3108,6 +3108,7 @@ test("demand-driven host windows bound automatic requests and render unknown tot
             windowRows: Map<string, Row>;
             recipientIdentities: { workers: Set<Promise<void>>; reset(): void };
             scheduleRecipientIdentityReads(rows: { sourceId: string; sourceGeneration: number }[]): void;
+            recipientSourceIsCurrent(sourceId: string, sourceGeneration: number, storeGeneration: number): boolean;
           };
           const sources = Array.from({ length: 6 }, (_, index) => ({ ...source, id: `queued-source-${index}` }));
           const demand = sources.map(account => ({ sourceId: account.id, sourceGeneration: account.generation }));
@@ -3117,13 +3118,17 @@ test("demand-driven host windows bound automatic requests and render unknown tot
               state: { ...store.getSnapshot().window!.state, sources: sources.map(account => ({ sourceId: account.id, generation: account.generation })) } } };
           queued.windowRows = new Map(sources.map(account => [account.id, { ...row(0), key: account.id, sourceId: account.id }]));
           const reads: string[] = [], releases: Array<() => void> = [];
+          let validations = 0;
+          const isCurrent = queued.recipientSourceIsCurrent.bind(queued);
+          queued.recipientSourceIsCurrent = (...args) => { validations++; return isCurrent(...args); };
           queuedStore.client.sendingIdentities = async sourceId => {
             reads.push(sourceId);
             await new Promise<void>(resolve => { releases.push(resolve); });
             return { sourceId, checkedAt: new Date().toISOString(), identities: [] };
           };
           try {
-            queued.scheduleRecipientIdentityReads(demand);
+            queued.scheduleRecipientIdentityReads(Array.from({ length: 1000 }, () => demand).flat());
+            assert.equal(validations, sources.length + 4, "duplicate rows validate once per source generation plus each dispatched worker, in both projection modes");
             assert.equal(reads.length, 4, "identity reads respect the worker bound");
             queued.state.window = { ...queued.state.window!, keys: [] };
             queued.scheduleRecipientIdentityReads([]);

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -8,7 +8,7 @@ import { classifyAttention, conversationAttention } from "../../shared/mail-atte
 import { AI_INPUT_POLICY_VERSION, AI_TRIAGE_VERSION, aiSortingStatus, type AiDecision, type AiTriageState } from "../../shared/ai-triage.ts";
 import { normalizeSplits, attentionSplit } from "../../shared/splits.ts";
 import { senderActivity, senderContact, senderConversations, senderHostname, type SenderHistoryMessage } from "../src/sender-context.ts";
-import { matchingRecipientAddress, matchingRecipientAlias } from "../src/recipient-address.ts";
+import { matchingRecipientAddress } from "../src/recipient-address.ts";
 import {
   advanceMail,
   appendOutgoing,
@@ -34,7 +34,7 @@ test("recipient alias display requires one verified incoming recipient match", (
   const aliases = ["notes@example.test", "billing@example.test"];
   const row = (to: string[], cc: string[] = [], folder = "inbox", deliveredTo?: string[]) => ({ folder, deliveredTo,
     to: to.map(email => ({ email })), cc: cc.map(email => ({ email })) });
-  const match = (rows: ReturnType<typeof row>[], known = aliases) => matchingRecipientAlias(rows, known.map(email => ({ email, isPrimary: false })), "primary@example.test");
+  const match = (rows: ReturnType<typeof row>[], known = aliases) => matchingRecipientAddress(rows, known.map(email => ({ email, isPrimary: false })), "primary@example.test");
   assert.equal(match([row(["NOTES@example.test", "external@example.test"])]), aliases[0]);
   assert.equal(match([row(["external@example.test"], [aliases[0]])]), aliases[0]);
   assert.equal(match([row([aliases[0]]), row([aliases[0]])]), aliases[0]);
@@ -42,7 +42,7 @@ test("recipient alias display requires one verified incoming recipient match", (
   assert.equal(match([row([aliases[0]]), row([aliases[1]], [], "sent")]), aliases[0]);
   assert.equal(match([row([aliases[0]], [aliases[1]])]), undefined);
   assert.equal(match([row([aliases[0]]), row([aliases[1]])]), undefined);
-  assert.equal(match([row(["primary@example.test"])], [...aliases, "PRIMARY@example.test"]), undefined);
+  assert.equal(match([row(["primary@example.test"])], [...aliases, "PRIMARY@example.test"]), "primary@example.test");
   assert.equal(match([row(["external@example.test"])]), undefined);
   assert.equal(match([row([aliases[0]])], []), undefined);
   assert.equal(match([row([aliases[0]], [], "sent")]), undefined);
@@ -55,10 +55,9 @@ test("recipient alias display requires one verified incoming recipient match", (
   assert.equal(match([row(aliases, [], "inbox", [aliases[1]])]), aliases[1]);
   assert.equal(match([row([], [], "inbox", aliases)]), undefined);
   assert.equal(match([row([], [], "inbox", ["unknown@example.test"])]), undefined);
-  assert.equal(match([row([], [], "inbox", ["primary@example.test"])], [...aliases, "primary@example.test"]), undefined);
+  assert.equal(match([row([], [], "inbox", ["primary@example.test"])], [...aliases, "primary@example.test"]), "primary@example.test");
   assert.equal(match([row([], [], "inbox", [aliases[0]]), row([], [], "inbox", [aliases[1]])]), undefined);
-  assert.equal(matchingRecipientAlias([row([], [], "inbox", ["provider-primary@example.test"])], [{ email: "provider-primary@example.test", isPrimary: true }], "different-owner@example.test"), undefined);
-  assert.equal(matchingRecipientAlias([row(["provider-primary@example.test"])], [{ email: "provider-primary@example.test", isPrimary: true }], "different-owner@example.test"), undefined);
+  assert.equal(matchingRecipientAddress([row([], [], "inbox", ["provider-primary@example.test"])], [{ email: "provider-primary@example.test", isPrimary: true }], "different-owner@example.test"), "provider-primary@example.test");
   for (const folder of ["scheduled", "outbox", "unsent", "queued", "SENT", "draft"]) {
     assert.equal(match([row([aliases[0]], [], folder)]), undefined, folder);
     assert.equal(match([row([], [], folder, [aliases[0]])]), undefined, folder);
@@ -680,6 +679,16 @@ test("SDK-backed sending identities support bounded row aliases and preserve exp
     host.store.receive({ owner: host.owner, storeId: nativeBox.id, accountId: sourceId }, {
       from: "sender@example.test", to: nativeBox.email, subject: "Explicit primary recipient", text: "Fictional primary recipient.",
     });
+    const orderedRecipients = [
+      { name: "alias first", to: [alias, nativeBox.email], cc: [], from: alias },
+      { name: "primary first", to: [nativeBox.email, alias], cc: [], from: nativeBox.email },
+      { name: "To before Cc", to: [nativeBox.email], cc: [alias], from: nativeBox.email },
+      { name: "Cc fallback", to: ["external@example.test"], cc: [alias, nativeBox.email], from: alias },
+      { name: "skip unknown and retain order", to: ["unknown@example.test", alias.toUpperCase(), alias, nativeBox.email], cc: [], from: alias },
+    ];
+    for (const scenario of orderedRecipients) host.store.receive({ owner: host.owner, storeId: nativeBox.id, accountId: sourceId }, {
+      from: "sender@example.test", to: scenario.to, cc: scenario.cc, subject: `Ordered recipients: ${scenario.name}`, text: "Fictional ordered recipients.",
+    });
     await host.inbox.sync(host.owner, sourceId, { folder: "all", lane: "latest", limit: 100 });
     const storage = new Map<string, string>();
     Object.assign(globalThis, { location: new URL("http://localhost:41999"), window: new EventTarget(),
@@ -841,6 +850,30 @@ test("SDK-backed sending identities support bounded row aliases and preserve exp
     const forward = await store.newDraft(primary.id, { mode: "forward", mail, sourceMessageId });
     assert.equal(created.at(-1)!.from, primary.email, "forward default is unchanged");
     await store.discardDraft(forward.id);
+
+    for (const scenario of orderedRecipients) {
+      const context = store.getSnapshot().mail.find(value => value.account === primary.id && value.subject === `Ordered recipients: ${scenario.name}`)!;
+      const messageId = context.messages.at(-1)!.id;
+      for (const mode of ["new", "reply", "replyAll"] as const) {
+        const draft = await store.newDraft(primary.id, { mode, mail: context, sourceMessageId: messageId,
+          ...(mode === "new" ? { to: "sender@example.test" } : {}) });
+        assert.equal(draft.from, scenario.from, `${mode}: ${scenario.name}`);
+        if (mode === "new") {
+          assert.equal(draft.sourceMessageId, undefined); assert.equal(draft.threadId, undefined);
+          assert.equal(draft.subject, ""); assert.equal(draft.body, "<div></div>");
+        }
+        await store.discardDraft(draft.id);
+      }
+    }
+
+    const addressMailbox = await host.inbox.createMailbox(host.owner, { sourceId, name: "Alias-only sender", selector: { kind: "address", value: alias }, defaultSender: alias });
+    await host.inbox.syncMailbox(host.owner, addressMailbox.id, { folder: "inbox", lane: "latest", limit: 100 });
+    await store.refresh(true);
+    const scopedMail = store.getSnapshot().mail.find(value => value.account === addressMailbox.id && value.subject === "Ordered recipients: primary first")!;
+    assert.ok(scopedMail, "the incoming message belongs to the alias-only mailbox");
+    const scopedDraft = await store.newDraft(addressMailbox.id, { mail: scopedMail, sourceMessageId: scopedMail.messages.at(-1)!.id, to: "sender@example.test" });
+    assert.equal(scopedDraft.from, alias, "skip an earlier authorized source identity outside the selected mailbox");
+    await store.discardDraft(scopedDraft.id);
 
     store.editDraft({ ...saved, from: "removed@example.test" });
     await store.flushDraft(saved.id);

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -956,13 +956,16 @@ test("MailRow separates incoming recipient identities from sent To addresses", a
     index: 0, highlighted: false, selected: false, sent, showSnippets: false,
   }));
   const alias = render("notes@example.test");
-  assert.match(alias, /class="row-recipients" role="cell" title="notes@example.test">notes@example.test<\/span>/);
-  assert.doesNotMatch(alias, />To:|No To recipients/);
+  assert.match(alias, /class="row-recipients" role="cell" title="To: notes@example.test">To: notes@example.test<\/span>/);
+  assert.doesNotMatch(alias, /No To recipients/);
   const primary = render("primary@example.test");
-  assert.match(primary, /title="primary@example.test">primary@example.test<\/span>/);
-  const blank = render();
-  assert.match(blank, /class="row-recipients" role="cell"><\/span>/);
-  for (const html of [alias, primary, blank]) assert.doesNotMatch(html, /actual-to@example.test|private-bcc@example.test|cc-only@example.test|owner@example.test/);
+  assert.match(primary, /title="To: primary@example.test">To: primary@example.test<\/span>/);
+  const fallback = render(undefined, false, ["actual-to@example.test"]);
+  assert.match(fallback, /title="To: Actual Recipient &lt;actual-to@example.test&gt;">To: actual-to@example.test<\/span>/);
+  assert.match(render(undefined, false, []), /title="No To recipients">No To recipients<\/span>/);
+  assert.match(render("notes@example.test", false, []), />To: notes@example.test<\/span>/);
+  for (const html of [alias, primary]) assert.doesNotMatch(html, /actual-to@example.test|private-bcc@example.test|cc-only@example.test|owner@example.test/);
+  assert.doesNotMatch(fallback, /private-bcc@example.test|cc-only@example.test|owner@example.test/);
   const sent = render("notes@example.test", true, ["actual-to@example.test"]);
   assert.match(sent, /title="To: Actual Recipient &lt;actual-to@example.test&gt;">To: actual-to@example.test<\/span>/);
   assert.doesNotMatch(sent, /notes@example.test|private-bcc@example.test|cc-only@example.test/);

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -788,6 +788,23 @@ test("SDK-backed sending identities support bounded row aliases and preserve exp
     assert.equal(mail.to, alias, "row To is the actual header recipient, not the source owner");
     assert.deepEqual(mail.toAddresses, [alias]);
     assert.deepEqual(store.getSnapshot().mail.find(value => value.account === UNIFIED_ACCOUNT && value.subject === mail.subject)!.toAddresses, [alias]);
+    const contactDraft = await store.newDraft(primary.id, { to: "sender@example.test", mail, sourceMessageId });
+    assert.equal(contactDraft.from, alias, "contact compose inherits the selected message's authorized alias");
+    assert.equal(contactDraft.to, "sender@example.test");
+    assert.equal(contactDraft.mode, "new");
+    assert.equal(contactDraft.subject, ""); assert.equal(contactDraft.body, "<div></div>");
+    assert.equal(contactDraft.sourceMessageId, undefined); assert.equal(contactDraft.threadId, undefined);
+    assert.equal(Object.hasOwn(created.at(-1)!, "sourceMessageId"), false, "a new conversation must not carry reply headers");
+    await store.reloadDraft(contactDraft.id);
+    assert.equal(store.getSnapshot().drafts.find(draft => draft.id === contactDraft.id)!.from, alias, "the inferred sender is durable");
+    await store.discardDraft(contactDraft.id);
+    const createdBeforeFailure = created.length;
+    failIdentity = true;
+    await assert.rejects(store.newDraft(primary.id, { to: "sender@example.test", mail, sourceMessageId }), error => error instanceof ApiError && error.code === "PROVIDER_UNAVAILABLE");
+    assert.equal(created.length, createdBeforeFailure, "identity lookup failure does not silently compose from the primary address");
+    failIdentity = false;
+    await assert.rejects(store.newDraft(secondary.id, { to: "sender@example.test", mail, sourceMessageId }), /no longer belongs to this mailbox/);
+    assert.equal(created.length, createdBeforeFailure, "context cannot cross source ownership");
     for (const mode of ["reply", "replyAll"] as const) {
       const reply = await store.newDraft(primary.id, { mode, mail, sourceMessageId });
       assert.equal(Object.hasOwn(created.at(-1)!, "from"), false, "implicit replies leave sender selection to the SDK");

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -8,7 +8,7 @@ import { classifyAttention, conversationAttention } from "../../shared/mail-atte
 import { AI_INPUT_POLICY_VERSION, AI_TRIAGE_VERSION, aiSortingStatus, type AiDecision, type AiTriageState } from "../../shared/ai-triage.ts";
 import { normalizeSplits, attentionSplit } from "../../shared/splits.ts";
 import { senderActivity, senderContact, senderConversations, senderHostname, type SenderHistoryMessage } from "../src/sender-context.ts";
-import { matchingRecipientAlias } from "../src/recipient-alias.ts";
+import { matchingRecipientAddress, matchingRecipientAlias } from "../src/recipient-alias.ts";
 import {
   advanceMail,
   appendOutgoing,
@@ -63,6 +63,26 @@ test("recipient alias display requires one verified incoming recipient match", (
     assert.equal(match([row([aliases[0]], [], folder)]), undefined, folder);
     assert.equal(match([row([], [], folder, [aliases[0]])]), undefined, folder);
     assert.equal(match([row([aliases[0]]), row([aliases[1]], [], folder)]), aliases[0], folder);
+  }
+  const primary = "primary@example.test";
+  const identities = [{ email: primary, isPrimary: true }, ...aliases.map(email => ({ email, isPrimary: false }))];
+  const display = (rows: ReturnType<typeof row>[]) => matchingRecipientAddress(rows, identities, primary);
+  assert.equal(display([row(["PRIMARY@example.test"])]), primary);
+  assert.equal(display([row([], [primary])]), primary);
+  assert.equal(display([row([], [], "inbox", [primary])]), primary);
+  assert.equal(display([row([primary]), row([primary])]), primary);
+  assert.equal(display([row([aliases[0]], [], "inbox", [primary])]), aliases[0], "primary delivery must not overwrite a To alias");
+  assert.equal(display([row([primary, aliases[0]])]), aliases[0]);
+  assert.equal(display([row([primary]), row([aliases[0]])]), aliases[0]);
+  assert.equal(display([row([primary, ...aliases])]), undefined, "primary matches cannot hide alias ambiguity");
+  assert.equal(display([row([], [], "inbox", [primary, ...aliases])]), undefined);
+  assert.equal(display([row(["unknown@example.test"])]), undefined);
+  assert.equal(display([row([])]), undefined);
+  assert.equal(matchingRecipientAddress([row([primary])], [], primary), undefined, "failed identity discovery does not invent a recipient");
+  assert.equal(matchingRecipientAddress([row([primary])], [{ email: primary, isPrimary: false }], primary), primary);
+  assert.equal(matchingRecipientAddress([row(["provider-primary@example.test"])], [{ email: "provider-primary@example.test", isPrimary: true }], primary), "provider-primary@example.test");
+  for (const folder of ["sent", "drafts", "scheduled", "outbox", "unsent", "queued", "SENT", "draft"]) {
+    assert.equal(display([row([primary], [], folder, [primary])]), undefined, folder);
   }
 });
 
@@ -657,6 +677,9 @@ test("SDK-backed sending identities support bounded row aliases and preserve exp
     host.store.receive({ owner: host.owner, storeId: nativeBox.id, accountId: sourceId }, {
       from: "sender@example.test", to: alias, subject: "Explicit alias reply", text: "Fictional alias recipient.",
     });
+    host.store.receive({ owner: host.owner, storeId: nativeBox.id, accountId: sourceId }, {
+      from: "sender@example.test", to: nativeBox.email, subject: "Explicit primary recipient", text: "Fictional primary recipient.",
+    });
     await host.inbox.sync(host.owner, sourceId, { folder: "all", lane: "latest", limit: 100 });
     const storage = new Map<string, string>();
     Object.assign(globalThis, { location: new URL("http://localhost:41999"), window: new EventTarget(),
@@ -692,6 +715,10 @@ test("SDK-backed sending identities support bounded row aliases and preserve exp
     await until(() => store.getSnapshot().mail.some(mail => mail.subject === "Explicit alias reply" && mail.recipientAlias === alias));
     assert.ok(identityReads.length <= store.getSnapshot().accounts.length, "legacy rows share bounded per-source identity discovery");
     const primary = store.getSnapshot().accounts.find(box => box.sourceId === sourceId)!;
+    for (const account of [primary.id, UNIFIED_ACCOUNT]) {
+      assert.equal(store.getSnapshot().mail.find(mail => mail.account === account && mail.subject === "Explicit primary recipient")?.recipientAlias,
+        nativeBox.email, "legacy individual and unified rows display the matched primary address");
+    }
     const secondary = store.getSnapshot().accounts.find(box => box.sourceId === host!.store.link(host!.owner, secondBox.id)!.accountId)!;
     assert.equal(primary.sourceGeneration, (await host.inbox.account(host.owner, sourceId)).generation);
     const values = await store.sendingIdentities(primary.id);
@@ -2891,7 +2918,7 @@ test("demand-driven host windows bound automatic requests and render unknown tot
         const summary: import("inbox-sdk/types").MailboxMessageSummary = {
           id: messageId, accountId: source.id, sourceId: source.id, threadId: `thread-${index}`, revision: 1,
           from: { name: "Fictional sender", email: "sender@example.test" },
-          to: index === 0 ? [] : [{ name: "Notes", email: "notes@example.test" }], cc: [], deliveredTo: index === 0 ? ["notes@example.test"] : undefined,
+          to: index === 0 ? [] : [{ name: "Recipient", email: index === 2 ? source.email : "notes@example.test" }], cc: [], deliveredTo: index === 0 ? ["notes@example.test"] : undefined,
           subject: `Fictional page row ${index}`, preview: "Bounded alias row.",
           receivedAt: new Date(Date.parse(deadline) - index * 1000).toISOString(), isRead: false, isStarred: false, folder: "inbox",
           folderIds: [], labelIds: [], hasAttachments: false,
@@ -2900,7 +2927,7 @@ test("demand-driven host windows bound automatic requests and render unknown tot
         return { key: id, sourceId: source.id, threadId: `thread-${index}`, sourceGeneration: 1, revision: 1, pageCursor: `row-${index}`,
           mail: { ...inbox, id, account: box.id, mailboxId: box.id, sourceId: source.id, sourceGeneration: source.generation, sdkThreadId: `thread-${index}`, subject: `Fictional page row ${index}`,
             receivedAt: Date.parse(deadline) - index * 1000, folder: "Inbox", locations: ["Inbox"], messages: [{ ...inbox.messages[0], id: messageId, body: "", loaded: false }] },
-          summaries: name === "full" && index <= 1 ? [summary] : [], messagesComplete: name === "full" && index === 0,
+          summaries: name === "full" && index <= 2 ? [summary] : [], messagesComplete: name === "full" && (index === 0 || index === 2),
           counts: { messages: 1, memberships: 1, unread: 1, done: 0, snoozed: 0 },
           targets: [{ mailboxId: box.id, messageId, revision: 1 }], targetsComplete: true, actionContextComplete: false, contextVersion: `context-${index}` };
       };
@@ -2982,6 +3009,8 @@ test("demand-driven host windows bound automatic requests and render unknown tot
       assert.equal(changes.length, 0, `${name}: incomplete context does not start an index-completion poller`);
       if (name === "full") {
         await until(() => store.getSnapshot().mail.find(mail => mail.id === row(0).key)?.recipientAlias === "notes@example.test", "the Delivered-To-only source alias appears without a body read");
+        assert.equal(store.getSnapshot().mail.find(mail => mail.id === row(2).key)?.recipientAlias, source.email,
+          "complete bounded-window rows display the matched primary address without a body read");
         assert.equal(store.getSnapshot().mail.find(mail => mail.id === row(1).key)?.recipientAlias, undefined,
           "an incomplete conversation stays blank because an omitted message could contain another alias");
         assert.equal(identityReads, 1, "one loaded source produces one identity request, not one request per row");

--- a/apps/web/tests/mail-model.test.ts
+++ b/apps/web/tests/mail-model.test.ts
@@ -901,10 +901,10 @@ test("SDK-backed sending identities support bounded row aliases and preserve exp
   }
 });
 
-test("MailRow renders only the bare verified recipient alias", async () => {
+test("MailRow separates incoming recipient identities from sent To addresses", async () => {
   if (!process.versions.bun) {
     const result = await new Promise<{ code: number | null; output: string }>((resolve, reject) => {
-      const child = spawn("bun", ["--no-env-file", "test", import.meta.filename, "--test-name-pattern", "MailRow renders only"], {
+      const child = spawn("bun", ["--no-env-file", "test", import.meta.filename, "--test-name-pattern", "MailRow separates incoming"], {
         env: { ...process.env, INBOX_TEST_LIVE: "false" }, stdio: ["ignore", "pipe", "pipe"],
       });
       let output = "";
@@ -916,18 +916,26 @@ test("MailRow renders only the bare verified recipient alias", async () => {
   const [{ createElement }, { renderToStaticMarkup }, { default: MailRow }] = await Promise.all([
     import("react"), import("react-dom/server"), import("../src/MailRow.tsx"),
   ]);
-  const render = (recipientAlias?: string) => renderToStaticMarkup(createElement(MailRow, {
-    mail: { ...inbox, to: "actual-to@example.test", toAddresses: ["actual-to@example.test"], recipientAlias,
+  const render = (recipientAlias?: string, sent = false, toAddresses?: string[], to = "Actual Recipient <actual-to@example.test>") => renderToStaticMarkup(createElement(MailRow, {
+    mail: { ...inbox, to, toAddresses, recipientAlias,
       account: UNIFIED_ACCOUNT, accountEmail: "owner@example.test", mailboxNames: ["Receiving mailbox"],
       messages: [{ ...inbox.messages[0], to: "actual-to@example.test", cc: "cc-only@example.test", bcc: "private-bcc@example.test" }] },
-    index: 0, highlighted: false, selected: false, sent: false, showSnippets: false,
+    index: 0, highlighted: false, selected: false, sent, showSnippets: false,
   }));
   const alias = render("notes@example.test");
   assert.match(alias, /class="row-recipients" role="cell" title="notes@example.test">notes@example.test<\/span>/);
   assert.doesNotMatch(alias, />To:|No To recipients/);
+  const primary = render("primary@example.test");
+  assert.match(primary, /title="primary@example.test">primary@example.test<\/span>/);
   const blank = render();
   assert.match(blank, /class="row-recipients" role="cell"><\/span>/);
-  for (const html of [alias, blank]) assert.doesNotMatch(html, /actual-to@example.test|private-bcc@example.test|cc-only@example.test|owner@example.test/);
+  for (const html of [alias, primary, blank]) assert.doesNotMatch(html, /actual-to@example.test|private-bcc@example.test|cc-only@example.test|owner@example.test/);
+  const sent = render("notes@example.test", true, ["actual-to@example.test"]);
+  assert.match(sent, /title="To: Actual Recipient &lt;actual-to@example.test&gt;">To: actual-to@example.test<\/span>/);
+  assert.doesNotMatch(sent, /notes@example.test|private-bcc@example.test|cc-only@example.test/);
+  assert.match(render(undefined, true, ["first@example.test", "second@example.test"]), />To: first@example.test, second@example.test<\/span>/);
+  assert.match(render(undefined, true, []), />No To recipients<\/span>/);
+  assert.match(render(undefined, true, undefined, "legacy@example.test"), /title="To: legacy@example.test">To: legacy@example.test<\/span>/);
 });
 test("SDK-backed optimistic flags retain conditional intent through latency, failures and overlapping views", async () => {
   // The ordinary web runner is Node; the actual SDK intentionally uses

--- a/packages/inbox-sdk/package.json
+++ b/packages/inbox-sdk/package.json
@@ -10,6 +10,7 @@
     "./provider": "./server/sdk/types.ts",
     "./providers": "./src/providers.ts",
     "./client": "./src/client.ts",
+    "./sender-selection": "./src/sender-selection.ts",
     "./http": "./src/http.ts",
     "./media": {
       "types": "./src/media.ts",

--- a/packages/inbox-sdk/server/sdk/gmail.ts
+++ b/packages/inbox-sdk/server/sdk/gmail.ts
@@ -137,6 +137,26 @@ function header(part: GmailPart | undefined, name: string): string {
   return part?.headers?.find((item) => item.name.toLowerCase() === name.toLowerCase())?.value ?? ''
 }
 
+function validAddress(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length > 254) return false
+  const parts = value.split('@')
+  const local = parts[0]!
+  const domain = parts[1]
+  return parts.length === 2 && local.length <= 64 &&
+    /^[a-z\d!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z\d!#$%&'*+/=?^_`{|}~-]+)*$/i.test(local) &&
+    Boolean(domain && domain.split('.').every(label =>
+      /^[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?$/i.test(label)))
+}
+
+/** Preserve repeated headers without promoting forwarding hints to delivery provenance. */
+function deliveredTo(part: GmailPart | undefined): string[] {
+  return [...new Set((part?.headers ?? []).flatMap(item => {
+    if (item.name.toLowerCase() !== 'delivered-to' || typeof item.value !== 'string') return []
+    const email = item.value.trim().toLowerCase()
+    return validAddress(email) ? [email] : []
+  }))]
+}
+
 function normalizeContentId(value: string | undefined): string {
   if (!value) return ''
 
@@ -544,6 +564,7 @@ export class GmailProvider implements InboxProvider {
       to: parseParticipants(header(message.payload, 'To')),
       cc: parseParticipants(header(message.payload, 'Cc')),
       bcc: parseParticipants(header(message.payload, 'Bcc')),
+      deliveredTo: deliveredTo(message.payload),
       replyTo: parseParticipants(header(message.payload, 'Reply-To')),
       ...(header(message.payload, 'Message-ID') ? { rfcMessageId: header(message.payload, 'Message-ID') } : {}),
       ...(header(message.payload, 'In-Reply-To') ? { inReplyTo: header(message.payload, 'In-Reply-To') } : {}),
@@ -658,16 +679,6 @@ export class GmailProvider implements InboxProvider {
   }
 
   async identities(): Promise<{ sending: readonly SendingIdentity[] }> {
-    const validAddress = (value: unknown): value is string => {
-      if (typeof value !== 'string' || value.length > 254) return false
-      const parts = value.split('@')
-      const local = parts[0]!
-      const domain = parts[1]
-      return parts.length === 2 && local.length <= 64 &&
-        /^[a-z\d!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z\d!#$%&'*+/=?^_`{|}~-]+)*$/i.test(local) &&
-        Boolean(domain && domain.split('.').every(label =>
-          /^[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?$/i.test(label)))
-    }
     // OAuth grants can be token-only; Google's authenticated response supplies the primary identity.
     const primary = this.credentials.email
     if (primary !== undefined && !validAddress(primary)) throw new ProviderError('gmail', 'VALIDATION', 'Invalid expected primary email address')

--- a/packages/inbox-sdk/src/contracts.ts
+++ b/packages/inbox-sdk/src/contracts.ts
@@ -422,6 +422,8 @@ export interface MessageSummary {
   from: Participant
   to: Participant[]
   cc: Participant[]
+  /** Untrusted Delivered-To hints, separate from authenticated delivery provenance. Absent in older caches. */
+  deliveredTo?: string[]
   subject: string
   preview: string
   receivedAt: string

--- a/packages/inbox-sdk/src/core.ts
+++ b/packages/inbox-sdk/src/core.ts
@@ -8,6 +8,7 @@ import { sanitizeEmailBody } from '../server/sanitize'
 import { createMediaStore } from './media'
 import { mailFacts } from './mail-facts'
 import { mailPreview } from './mail-preview'
+import { senderFromRecipients } from './sender-selection'
 import { FORWARDING_BODY_BYTES, FORWARDING_DEPTH, forwardingRfcId, isForwardedCopy, type ForwardingBody, type ForwardingMessage } from './forwarding'
 import { ProviderError, ProviderMutationError, type InboxProvider, type MailAccount, type MailMessage, type SyncResult, type SendInput } from '../server/sdk/types'
 import { CredentialError, InboxError, MAILBOX_SYNC_PROBLEM_CODES, type MailboxSyncStatus, type MailboxSyncProblemCode, type Account, type BlobInfo, type ChangeEvent, type Changes, type CredentialContext, type CredentialState, type Draft,
@@ -3069,7 +3070,8 @@ export function createInbox(options: InboxOptions): Inbox {
         if (source.account !== account.id) throw new InboxError('NOT_FOUND', 'Source message not found.', 404)
         const base = summary(source); const body = JSON.parse(source.body)
         const native = JSON.parse(account.native)
-        const identities = (sending?.identities ?? nativeSendingIdentities(native)).map(identity => identity.email)
+        const catalog = sending?.identities ?? nativeSendingIdentities(native)
+        const identities = catalog.map(identity => identity.email)
         const own = new Set(identities.map(email => email.toLowerCase()))
         if (replying && input.from === undefined) {
           const box = input.mailboxId ? JSON.parse(mailboxRow(owner, input.mailboxId, true).data) as Mailbox : null
@@ -3078,12 +3080,9 @@ export function createInbox(options: InboxOptions): Inbox {
             if (box) { try { assertMailboxSender(box, email) } catch { return undefined } }
             return identities.find(value => value.toLowerCase() === email.toLowerCase())
           }
-          const matches = [...new Set([...base.to, ...base.cc].flatMap(recipient => eligible(recipient.email) ?? []))]
-          const delivered = [...new Set((base.deliveredTo ?? []).flatMap(email => eligible(email) ?? []))]
-          // Keep an unambiguous To/Cc choice. Delivered-To fills missing recipients
-          // and disambiguates aliases, but never expands the authorized sender set.
-          const from = (base.folder === 'sent' ? eligible(base.from.email) : undefined) ?? (matches.length === 1 ? matches[0] : undefined)
-            ?? (delivered.length === 1 ? delivered[0] : undefined) ?? eligible(box?.defaultSender) ?? eligible(native.email)
+          const eligibleIdentities = catalog.filter(identity => eligible(identity.email))
+          const from = (base.folder === 'sent' ? eligible(base.from.email) : undefined) ?? senderFromRecipients(base, eligibleIdentities)
+            ?? eligible(box?.defaultSender) ?? eligible(native.email)
             ?? (identities.length === 1 ? eligible(identities[0]) : undefined)
           if (!from) throw new InboxError('FORBIDDEN_SENDER', 'No authorized sender is available for this reply.', 403)
           prepared.from = from

--- a/packages/inbox-sdk/src/core.ts
+++ b/packages/inbox-sdk/src/core.ts
@@ -1407,6 +1407,15 @@ export function createInbox(options: InboxOptions): Inbox {
       from: mail.from, to: mail.to, cc: mail.cc, subject: mail.subject, preview: mailPreview(mail), receivedAt: mail.receivedAt,
       isRead: mail.isRead, isStarred: mail.isStarred, folder: mail.folder, folderIds,
       labelIds: [], hasAttachments: attachments.length > 0, snoozedUntil: null, facts: mailFacts(mail) }
+    // Partial provider observations may omit headers. Preserve only this message's
+    // retained hints, never infer them from authenticated mailbox membership proof.
+    const deliveredTo: unknown = mail.deliveredTo ?? (old ? (JSON.parse(old.confirmed) as MessageSummary).deliveredTo : undefined)
+    if (deliveredTo !== undefined) {
+      if (!Array.isArray(deliveredTo) || deliveredTo.some(email => typeof email !== 'string' || email.length > 320 || !/^[^\s<>@]+@[^\s<>@]+$/.test(email))) {
+        throw new InboxError('INVALID_PROVIDER', 'Provider supplied invalid Delivered-To hints.', 502)
+      }
+      summary.deliveredTo = [...new Set(deliveredTo.map(email => email.toLowerCase()))]
+    }
     const body = JSON.stringify({ bcc: mail.bcc, bodyText: mail.bodyText, bodyHtml: mail.bodyHtml, attachments,
       replyTo: normalized.replyTo, rfcMessageId: normalized.rfcMessageId, references: normalized.references, inReplyTo: normalized.inReplyTo })
     summary.bodyRevision = createHmac('sha256', options.encryptionKey)
@@ -3070,7 +3079,11 @@ export function createInbox(options: InboxOptions): Inbox {
             return identities.find(value => value.toLowerCase() === email.toLowerCase())
           }
           const matches = [...new Set([...base.to, ...base.cc].flatMap(recipient => eligible(recipient.email) ?? []))]
-          const from = (base.folder === 'sent' ? eligible(base.from.email) : undefined) ?? (matches.length === 1 ? matches[0] : undefined) ?? eligible(box?.defaultSender) ?? eligible(native.email)
+          const delivered = [...new Set((base.deliveredTo ?? []).flatMap(email => eligible(email) ?? []))]
+          // Keep an unambiguous To/Cc choice. Delivered-To fills missing recipients
+          // and disambiguates aliases, but never expands the authorized sender set.
+          const from = (base.folder === 'sent' ? eligible(base.from.email) : undefined) ?? (matches.length === 1 ? matches[0] : undefined)
+            ?? (delivered.length === 1 ? delivered[0] : undefined) ?? eligible(box?.defaultSender) ?? eligible(native.email)
             ?? (identities.length === 1 ? eligible(identities[0]) : undefined)
           if (!from) throw new InboxError('FORBIDDEN_SENDER', 'No authorized sender is available for this reply.', 403)
           prepared.from = from

--- a/packages/inbox-sdk/src/http.ts
+++ b/packages/inbox-sdk/src/http.ts
@@ -103,6 +103,7 @@ const sourceFacts = z.object({
 })
 const messageSummary = z.object({
   id, accountId: id, threadId: id, revision, from: participant, to: z.array(participant), cc: z.array(participant),
+  deliveredTo: z.array(z.string().min(1).max(320)).optional(),
   subject: z.string(), preview: z.string(), receivedAt: z.string(), isRead: z.boolean(), isStarred: z.boolean(),
   folder: z.string(), folderIds: z.array(id), labelIds: z.array(id), hasAttachments: z.boolean(),
   snoozedUntil: z.string().nullable(), facts: sourceFacts.optional(), bodyRevision: opaque.optional(),

--- a/packages/inbox-sdk/src/sender-selection.ts
+++ b/packages/inbox-sdk/src/sender-selection.ts
@@ -1,0 +1,25 @@
+import type { Participant, SendingIdentity } from './contracts'
+
+const nonIncomingFolders = new Set(['sent', 'draft', 'drafts', 'scheduled', 'outbox', 'unsent', 'queued'])
+
+/**
+ * Select within an already authorized, mailbox-scoped catalog. Headers grant no authority.
+ * To order wins, then Cc order. Only a unique Delivered-To match may fill missing recipients.
+ * Explicit From, sent-message continuation and the default sender remain caller-owned.
+ */
+export function senderFromRecipients(message: {
+  folder: string
+  to: readonly Pick<Participant, 'email'>[]
+  cc: readonly Pick<Participant, 'email'>[]
+  deliveredTo?: readonly string[]
+}, identities: readonly Pick<SendingIdentity, 'email'>[]): string | undefined {
+  if (nonIncomingFolders.has(message.folder.toLowerCase())) return undefined
+  const own = new Map(identities.map(identity => [identity.email.toLowerCase(), identity.email]))
+  for (const recipient of [...message.to, ...message.cc]) {
+    const sender = own.get(recipient.email.toLowerCase())
+    if (sender !== undefined) return sender
+  }
+  // Repeated Delivered-To headers can describe distinct forwarding hops, not recipient order.
+  const delivered = new Set((message.deliveredTo ?? []).flatMap(email => own.get(email.toLowerCase()) ?? []))
+  return delivered.size === 1 ? delivered.values().next().value : undefined
+}

--- a/packages/inbox-sdk/src/sender-selection.ts
+++ b/packages/inbox-sdk/src/sender-selection.ts
@@ -1,6 +1,16 @@
-import type { Participant, SendingIdentity } from './contracts'
+import type { MailboxSelector, Participant, SendingIdentity } from './contracts'
 
 const nonIncomingFolders = new Set(['sent', 'draft', 'drafts', 'scheduled', 'outbox', 'unsent', 'queued'])
+
+/** Outgoing mail is not evidence for a receiving address or an inferred reply sender. */
+export const isIncomingRecipientFolder = (folder: string): boolean => !nonIncomingFolders.has(folder.toLowerCase())
+
+/** Filter an authorized catalog for UI selection. SDK sender validation remains authoritative. */
+export function sendingIdentityMatchesMailbox(email: string, selector: { kind?: MailboxSelector['kind']; value?: string }): boolean {
+  if (selector.kind === 'address') return email.toLowerCase() === selector.value?.toLowerCase()
+  if (selector.kind === 'domain') return email.split('@').at(-1)?.toLowerCase() === selector.value?.toLowerCase()
+  return true
+}
 
 /**
  * Select within an already authorized, mailbox-scoped catalog. Headers grant no authority.
@@ -13,7 +23,7 @@ export function senderFromRecipients(message: {
   cc: readonly Pick<Participant, 'email'>[]
   deliveredTo?: readonly string[]
 }, identities: readonly Pick<SendingIdentity, 'email'>[]): string | undefined {
-  if (nonIncomingFolders.has(message.folder.toLowerCase())) return undefined
+  if (!isIncomingRecipientFolder(message.folder)) return undefined
   const own = new Map(identities.map(identity => [identity.email.toLowerCase(), identity.email]))
   for (const recipient of [...message.to, ...message.cc]) {
     const sender = own.get(recipient.email.toLowerCase())

--- a/packages/inbox-sdk/src/types.ts
+++ b/packages/inbox-sdk/src/types.ts
@@ -73,6 +73,8 @@ export interface MailMessage {
   /** Authenticated delivery provenance, supplied by the SDK rather than recipient headers. */
   sourceDomains?: string[]
   deliveryRecipients?: string[]
+  /** Untrusted Delivered-To header hints. Never use these as mailbox or sending authority. */
+  deliveredTo?: string[]
   from: Participant
   to: Participant[]
   cc: Participant[]

--- a/packages/inbox-sdk/tests/api.test.ts
+++ b/packages/inbox-sdk/tests/api.test.ts
@@ -4,6 +4,7 @@ import { Hono } from 'hono'
 import { DomUtils, parseDocument } from 'htmlparser2'
 import { createHash, generateKeyPairSync, randomUUID, sign } from 'node:crypto'
 import { chmod, link, mkdir, mkdtemp, readFile, rename, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
 import { brotliCompressSync, deflateSync, gzipSync } from 'node:zlib'
 import { SaxesParser } from 'saxes'
@@ -58,7 +59,7 @@ import type {
   ProviderFolder, SendInput, SendResult, SyncContext, SyncCursor, SyncOptions, SyncResult,
 } from '../server/sdk/types'
 
-const TEMP_ROOT = '/private/var/folders/2j/6mslx1715gx8frsyn66sf1sh0000gn/T/opencode'
+const TEMP_ROOT = tmpdir()
 const FULL = 'reference-mail'
 const RESTRICTED = 'reference-read-only'
 const DYNAMIC = 'unanticipated-provider-2026'

--- a/packages/inbox-sdk/tests/api.test.ts
+++ b/packages/inbox-sdk/tests/api.test.ts
@@ -4669,7 +4669,7 @@ describe('bounded mailbox snapshot and changes', () => {
     const h = await fixture()
     h.discoveries.set('summary-scoped', { sources: ['alpha.example.test', 'beta.example.test'].map(value => ({ kind: 'domain' as const, value, canReceive: true, canSend: false, canFilter: true })), identities: [] })
     const html = `<html><head><style>td { color: navy }</style></head><body><script>fictionalUnsafe()</script><table>${'<tr><td onclick="fictionalUnsafe()">Fictional digest <a href="https://example.test/read">Read</a></td></tr>'.repeat(200)}</table></body></html>`
-    const { account, box } = await h.connect('alice', 'summary-scoped', [native('summary-alpha', { sourceDomains: ['alpha.example.test'], bodyHtml: html }), native('summary-beta', { sourceDomains: ['beta.example.test'] })], SCOPED)
+    const { account, box } = await h.connect('alice', 'summary-scoped', [native('summary-alpha', { sourceDomains: ['alpha.example.test'], deliveredTo: ['help@alpha.example.test'], bodyHtml: html }), native('summary-beta', { sourceDomains: ['beta.example.test'] })], SCOPED)
     const alpha = await h.inbox.createMailbox('alice', { sourceId: account.id, name: 'Alpha', selector: { kind: 'domain', value: 'alpha.example.test' } })
     const beta = await h.inbox.createMailbox('alice', { sourceId: account.id, name: 'Beta', selector: { kind: 'domain', value: 'beta.example.test' } })
     await h.sync('alice', account.id)
@@ -4714,6 +4714,7 @@ describe('bounded mailbox snapshot and changes', () => {
       expect(result).toMatchObject({ id: own.id, sourceId: account.id, threadId: own.threadId, bodyRevision: own.bodyRevision,
         memberships: [{ mailboxId: alpha.id, revision: 2, done: true, snoozedUntil: new Date(EPOCH + 86400000).toISOString() }] })
       expect(result.facts).toBeUndefined()
+      expect(result.deliveredTo).toEqual(['help@alpha.example.test'])
       for (const field of ['bodyHtml', 'bodyText', 'bodyDocument', 'attachments', 'bcc']) expect(result).not.toHaveProperty(field)
       expect(await client.mailboxMessageSummary(alpha.id, own.id)).toEqual(result)
       expect(wire.requests.at(-1)!.status).toBe(304)
@@ -4728,8 +4729,10 @@ describe('bounded mailbox snapshot and changes', () => {
       expect(bodyReads).toBe(0)
       const live = await client.mailboxMessagePage({ mailboxIds: [alpha.id] })
       expect(live.items[0]!.facts).toBeUndefined()
+      expect(live.items[0]!.deliveredTo).toEqual(result.deliveredTo)
       const conversations = await client.mailboxConversations({ mailboxIds: [alpha.id] })
       expect(conversations.items[0]!.messages[0]!.facts).toBeUndefined()
+      expect(conversations.items[0]!.messages[0]!.deliveredTo).toEqual(result.deliveredTo)
       expect(conversations.items[0]!.mailboxStates[0]).toMatchObject({ messageCount: 1, doneCount: 1, snoozedCount: 1 })
       expect(await client.mailboxCounts({ mailboxIds: [alpha.id], query: { done: true, snoozed: true } })).toMatchObject({ messages: 1, conversations: 1 })
       expect(bodyReads).toBe(0); expect(box.calls).toEqual(before)
@@ -7838,11 +7841,16 @@ describe('source-scoped sending identities', () => {
     const alias = { email: 'alias@example.test', isPrimary: false, isDefault: true }
     const second = { email: 'second@example.test', isPrimary: false, isDefault: false }
     const box = referenceMailbox('senders-reply', primary.email, [
-      native('alias', { to: [participant('ALIAS@example.test')], cc: [participant('colleague@example.test')], replyTo: [participant('desk@example.test')] }),
+      native('alias', { to: [participant('ALIAS@example.test')], cc: [participant('colleague@example.test')], replyTo: [participant('desk@example.test')], deliveredTo: [primary.email] }),
       native('ambiguous', { to: [participant(alias.email), participant(second.email)] }),
-      native('own-sent', { from: participant(second.email), to: [participant('recipient@example.test')], folder: 'sent' }),
+      native('own-sent', { from: participant(second.email), to: [participant('recipient@example.test')], folder: 'sent', deliveredTo: [alias.email] }),
       native('owned-incoming', { from: participant(second.email), to: [participant(alias.email)], folder: 'inbox' }),
       native('invented', { to: [participant('alias+invented@example.test')] }),
+      native('delivered-bcc', { to: [], deliveredTo: ['ALIAS@example.test', alias.email] }),
+      native('delivered-list', { to: [participant('list@example.test')], deliveredTo: [second.email] }),
+      native('delivered-disambiguated', { to: [participant(alias.email), participant(second.email)], deliveredTo: [second.email] }),
+      native('delivered-ambiguous', { to: [], deliveredTo: [alias.email, second.email] }),
+      native('delivered-unknown', { to: [], deliveredTo: ['alias+invented@example.test'] }),
     ])
     const h = await fixture({ providers: [{ id: DYNAMIC, name: DYNAMIC, create: credentials => ({
       ...box.adapter(credentials, DYNAMIC, fullCapabilities), async identities() { return { sending: [primary, alias, second] } },
@@ -7853,7 +7861,8 @@ describe('source-scoped sending identities', () => {
     const source = rows.find(row => row.subject === 'Subject alias')!
     const reply = await h.inbox.createDraft('alice', { accountId: account.id, mailboxId: account.id, mode: 'replyAll', sourceMessageId: source.id })
     expect(reply.from).toBe(alias.email); expect(reply.to).toEqual([participant('desk@example.test')]); expect(reply.cc).toEqual([participant('colleague@example.test')])
-    for (const [subject, from] of [['ambiguous', primary.email], ['own-sent', second.email], ['owned-incoming', alias.email], ['invented', primary.email]]) {
+    for (const [subject, from] of [['ambiguous', primary.email], ['own-sent', second.email], ['owned-incoming', alias.email], ['invented', primary.email],
+      ['delivered-bcc', alias.email], ['delivered-list', second.email], ['delivered-disambiguated', second.email], ['delivered-ambiguous', primary.email], ['delivered-unknown', primary.email]]) {
       const draft = await h.inbox.createDraft('alice', { accountId: account.id, mode: 'reply', sourceMessageId: rows.find(row => row.subject === `Subject ${subject}`)!.id })
       expect(draft.from).toBe(from)
     }
@@ -7862,6 +7871,8 @@ describe('source-scoped sending identities', () => {
     const edited = await h.inbox.updateDraft('alice', explicit.id, { bodyText: 'Keep my chosen sender' }, explicit.revision)
     await h.restart()
     expect(await h.inbox.draft('alice', explicit.id)).toMatchObject({ from: second.email, bodyText: edited.bodyText })
+    const bccSource = rows.find(row => row.subject === 'Subject delivered-bcc')!
+    expect((await h.inbox.createDraft('alice', { accountId: account.id, mode: 'reply', sourceMessageId: bccSource.id })).from).toBe(alias.email)
     expect(box.calls.getMessage).toEqual([]); expect(box.calls.send).toEqual([])
     await h.inbox.setPolicy('alice', { undoSendSeconds: 0 })
     const operation = await h.submit('alice', edited, 'explicit-alias-after-restart')
@@ -9674,7 +9685,7 @@ describe('pilot contract: server OAuth, configured mailboxes, and canonical mess
     })
     const { account } = await h.connect('alice', 'scope-proof', [
       shared, { ...shared, id: 'delivery-two' },
-      native('header-only', { to: [participant('help@alpha.example.test')], sourceDomains: ['beta.example.test'] }),
+      native('header-only', { to: [participant('help@alpha.example.test')], deliveredTo: ['help@alpha.example.test'], sourceDomains: ['beta.example.test'] }),
     ], SCOPED)
     const candidates = await h.json<MailboxCandidate[]>('alice', `/connections/${account.connectionId}/mailbox-candidates`)
     expect(candidates.map(item => item.selector)).toEqual(expect.arrayContaining([
@@ -9706,7 +9717,7 @@ describe('pilot contract: server OAuth, configured mailboxes, and canonical mess
   test('delivery evidence accumulates before unchanged-body and backfill shortcuts, then survives omissions and restart', async () => {
     const h = await fixture()
     h.discoveries.set('evidence-union', discovery)
-    const original = native('one-upstream-record', { bodyText: 'Authoritative body', sourceDomains: ['alpha.example.test'] })
+    const original = native('one-upstream-record', { bodyText: 'Authoritative body', sourceDomains: ['alpha.example.test'], deliveredTo: ['help@alpha.example.test'] })
     const { account, box } = await h.connect('alice', 'evidence-union', [original], SCOPED)
     const a = await h.json<Mailbox>('alice', '/mailboxes', {
       sourceId: account.id, name: 'Evidence A', selector: { kind: 'domain', value: 'alpha.example.test' },
@@ -9716,6 +9727,7 @@ describe('pilot contract: server OAuth, configured mailboxes, and canonical mess
     }, 'POST', 201)
     await h.json('alice', `/mailboxes/${a.id}/sync`, {}, 'POST')
     const first = (await h.inbox.mailboxMessages('alice', { mailboxIds: [a.id] })).items[0]!
+    expect(first.deliveredTo).toEqual(original.deliveredTo)
     expect((await h.inbox.mailboxMessages('alice', { mailboxIds: [b.id] })).total).toBe(0)
     const baseline = await h.inbox.changes('alice')
     box.nextSync(receipt([{ ...original, sourceDomains: ['beta.example.test'] }], 'same-body-new-scope'))
@@ -9728,16 +9740,26 @@ describe('pilot contract: server OAuth, configured mailboxes, and canonical mess
       sourceId: account.id, name: 'Historical address proof', selector: { kind: 'address', value: 'help@alpha.example.test' },
     }, 'POST', 201)
     expect((await h.inbox.mailboxMessages('alice', { mailboxIds: [historicalAddress.id] })).total).toBe(0)
-    box.nextSync(receipt([native(original.id, { bodyText: 'Obsolete backfill body', deliveryRecipients: ['help@alpha.example.test'] })], 'historical-detail'))
+    expect((await h.inbox.mailboxMessageSummary('alice', a.id, first.id)).deliveredTo).toEqual(original.deliveredTo)
+    box.nextSync(receipt([native(original.id, { bodyText: 'Obsolete backfill body', deliveryRecipients: ['help@alpha.example.test'], deliveredTo: ['desk@beta.example.test'] })], 'historical-detail'))
     await h.json('alice', `/mailboxes/${b.id}/sync`, { lane: 'backfill' }, 'POST')
     const union = await h.inbox.mailboxMessages('alice', { mailboxIds: [a.id, b.id] })
     expect(union.total).toBe(1)
     expect(union.items[0]!.id).toBe(first.id)
+    expect(union.items[0]!.deliveredTo).toEqual(original.deliveredTo)
     expect(union.items[0]!.memberships.map(item => item.mailboxId).sort()).toEqual([a.id, b.id].sort())
     expect((await h.inbox.mailboxMessage('alice', a.id, first.id)).bodyText).toBe(original.bodyText)
     expect((await h.inbox.mailboxMessage('alice', b.id, first.id)).bodyText).toBe(original.bodyText)
     expect((await h.inbox.mailboxMessage('alice', historicalAddress.id, first.id)).bodyText).toBe(original.bodyText)
     expect((await h.inbox.changes('alice', { since: baseline.state })).events.filter(event => event.type === 'mail.changed' && event.reason === 'arrival')).toEqual([])
+    const beforeClear = await h.inbox.mailboxMessagePage('alice', { mailboxIds: [a.id] })
+    box.nextSync(receipt([{ ...original, deliveredTo: [] }], 'explicitly-cleared-header-hints'))
+    await h.sync('alice', account.id)
+    const delta = await h.inbox.mailboxChanges('alice', { mailboxIds: [a.id], since: beforeClear.state, scopeState: beforeClear.scopeState })
+    expect(delta.upserts[0]!.deliveredTo).toEqual([])
+    expect(delta.upserts[0]!.bodyRevision).toBe(first.bodyRevision)
+    expect(delta.upserts[0]!.revision).toBeGreaterThan(first.revision)
+    expect(box.calls.getMessage).toEqual([])
   })
 
   test('unified counts and tied-timestamp pagination count canonical records rather than mailbox memberships', async () => {

--- a/packages/inbox-sdk/tests/api.test.ts
+++ b/packages/inbox-sdk/tests/api.test.ts
@@ -7836,7 +7836,7 @@ describe('source-scoped sending identities', () => {
     expect(box.calls.listMessages).toBe(0); expect(box.calls.getMessage).toEqual([])
   })
 
-  test('sending identities select only unambiguous authorized reply addresses, preserve explicit From and exclude current self aliases', async () => {
+  test('sending identities select the first authorized reply recipient, preserve explicit From and exclude current self aliases', async () => {
     const primary = { email: 'primary@example.test', isPrimary: true, isDefault: false }
     const alias = { email: 'alias@example.test', isPrimary: false, isDefault: true }
     const second = { email: 'second@example.test', isPrimary: false, isDefault: false }
@@ -7851,6 +7851,12 @@ describe('source-scoped sending identities', () => {
       native('delivered-disambiguated', { to: [participant(alias.email), participant(second.email)], deliveredTo: [second.email] }),
       native('delivered-ambiguous', { to: [], deliveredTo: [alias.email, second.email] }),
       native('delivered-unknown', { to: [], deliveredTo: ['alias+invented@example.test'] }),
+      native('alias-primary', { to: [participant(alias.email), participant(primary.email)], deliveredTo: [primary.email] }),
+      native('primary-alias', { to: [participant(primary.email), participant(alias.email)], deliveredTo: [alias.email] }),
+      native('to-before-cc', { to: [participant(primary.email)], cc: [participant(alias.email)] }),
+      native('cc-order', { to: [participant('external@example.test')], cc: [participant(second.email), participant(primary.email)] }),
+      native('skip-unknown', { to: [participant('unknown@example.test'), participant('ALIAS@example.test'), participant(alias.email), participant(primary.email)] }),
+      native('second-first', { to: [participant(second.email), participant(alias.email)] }),
     ])
     const h = await fixture({ providers: [{ id: DYNAMIC, name: DYNAMIC, create: credentials => ({
       ...box.adapter(credentials, DYNAMIC, fullCapabilities), async identities() { return { sending: [primary, alias, second] } },
@@ -7861,8 +7867,9 @@ describe('source-scoped sending identities', () => {
     const source = rows.find(row => row.subject === 'Subject alias')!
     const reply = await h.inbox.createDraft('alice', { accountId: account.id, mailboxId: account.id, mode: 'replyAll', sourceMessageId: source.id })
     expect(reply.from).toBe(alias.email); expect(reply.to).toEqual([participant('desk@example.test')]); expect(reply.cc).toEqual([participant('colleague@example.test')])
-    for (const [subject, from] of [['ambiguous', primary.email], ['own-sent', second.email], ['owned-incoming', alias.email], ['invented', primary.email],
-      ['delivered-bcc', alias.email], ['delivered-list', second.email], ['delivered-disambiguated', second.email], ['delivered-ambiguous', primary.email], ['delivered-unknown', primary.email]]) {
+    for (const [subject, from] of [['ambiguous', alias.email], ['own-sent', second.email], ['owned-incoming', alias.email], ['invented', primary.email],
+      ['delivered-bcc', alias.email], ['delivered-list', second.email], ['delivered-disambiguated', alias.email], ['delivered-ambiguous', primary.email], ['delivered-unknown', primary.email],
+      ['alias-primary', alias.email], ['primary-alias', primary.email], ['to-before-cc', primary.email], ['cc-order', second.email], ['skip-unknown', alias.email], ['second-first', second.email]]) {
       const draft = await h.inbox.createDraft('alice', { accountId: account.id, mode: 'reply', sourceMessageId: rows.find(row => row.subject === `Subject ${subject}`)!.id })
       expect(draft.from).toBe(from)
     }
@@ -10029,13 +10036,21 @@ describe('pilot contract: server OAuth, configured mailboxes, and canonical mess
   test('mailbox-bound drafts choose a verified scoped sender and detach cancels only their undispatched submissions', async () => {
     const h = await fixture()
     h.discoveries.set('scoped-drafts', discovery)
-    const { account, box } = await h.connect('alice', 'scoped-drafts', [], SCOPED)
+    const { account, box } = await h.connect('alice', 'scoped-drafts', [native('scoped-recipient-order', {
+      to: [participant('help@alpha.example.test'), participant('desk@beta.example.test')], sourceDomains: ['alpha.example.test', 'beta.example.test'],
+    })], SCOPED)
     const a = await h.json<Mailbox>('alice', '/mailboxes', {
       sourceId: account.id, name: 'Sender A', selector: { kind: 'domain', value: 'alpha.example.test' }, defaultSender: 'help@alpha.example.test',
     }, 'POST', 201)
     const b = await h.json<Mailbox>('alice', '/mailboxes', {
       sourceId: account.id, name: 'Sender B', selector: { kind: 'domain', value: 'beta.example.test' }, defaultSender: 'desk@beta.example.test',
     }, 'POST', 201)
+    await h.sync('alice', account.id)
+    const source = (await h.page()).items.find(message => message.subject === 'Subject scoped-recipient-order')!
+    for (const mailbox of [a, b]) {
+      const reply = await h.inbox.createDraft('alice', { accountId: account.id, mailboxId: mailbox.id, mode: 'reply', sourceMessageId: source.id })
+      expect(reply).toMatchObject({ from: mailbox.defaultSender })
+    }
     await invalid(await h.request('alice', `/mailboxes/${a.id}`, {
       method: 'PATCH', headers: { 'content-type': 'application/json', 'If-Match': await etag(h, 'alice', `/mailboxes/${a.id}`) },
       body: JSON.stringify({ defaultSender: b.defaultSender }),

--- a/packages/inbox-sdk/tests/provider.test.ts
+++ b/packages/inbox-sdk/tests/provider.test.ts
@@ -3762,6 +3762,38 @@ describe('Gmail sending identities', () => {
 })
 
 describe('Gmail read-only body and pagination regressions', () => {
+  test('Delivered-To keeps repeated top-level address hints without inventing authenticated delivery provenance', async () => {
+    const definition = builtInProviders.find(provider => provider.id === 'gmail')!
+    const native = { id: 'delivered-hints', threadId: 'delivered-thread', internalDate: '1767225600000', payload: {
+      mimeType: 'multipart/mixed', headers: [
+        { name: 'Delivered-To', value: ' NOTES@example.test ' },
+        { name: 'dELIVERED-tO', value: 'notes@example.test' },
+        { name: 'Delivered-To', value: 'billing@example.test' },
+        ...['', 'invalid', 'bad@@example.test', 'Name <forged@example.test>', 'a@example.test,b@example.test',
+          'a@example.test\r\nDelivered-To: forged@example.test', 'a@-bad.test', `${'x'.repeat(65)}@example.test`]
+          .map(value => ({ name: 'Delivered-To', value })),
+        { name: 'X-Delivered-To', value: 'forged@example.test' },
+        { name: 'To', value: 'list@example.test' },
+      ], parts: [{ partId: '0', mimeType: 'text/plain', headers: [{ name: 'Delivered-To', value: 'embedded@example.test' }],
+        body: { data: Buffer.from('Fictional list message.').toString('base64url') } }],
+    } }
+    const fetcher = (async (input: string | URL | Request, init?: RequestInit) => {
+      expect(String(input)).toBe('https://gmail.invalid/gmail/v1/users/me/messages/delivered-hints?format=full')
+      expect(init?.method ?? 'GET').toBe('GET')
+      return Response.json(native)
+    }) as typeof fetch
+    const provider = await definition.create({ accountId: 'gmail-delivered-hints', accessToken: 'offline-token',
+      scopes: ['https://www.googleapis.com/auth/gmail.readonly'], baseUrl: 'https://gmail.invalid/gmail/v1', fetch: fetcher })
+    try {
+      const message = await provider.getMessage(native.id)
+      expect(message.deliveredTo).toEqual(['notes@example.test', 'billing@example.test'])
+      expect(message.deliveryRecipients).toBeUndefined()
+      expect(message.to.map(recipient => recipient.email)).toEqual(['list@example.test'])
+      native.payload.headers = []
+      expect((await provider.getMessage(native.id)).deliveredTo).toEqual([])
+    } finally { await provider.disconnect() }
+  })
+
   test('explicit HTML UTF-8 declarations override legacy MIME only for valid original UTF-8 bytes', async () => {
     const definition = builtInProviders.find(provider => provider.id === 'gmail')!
     const plain = 'Plain caf\u00e9 body.'


### PR DESCRIPTION
## Scope

- Change and reason: Show receiving addresses in inbox rows and thread headers, and improve default sender selection for replies and contact composition. Covers Bcc and list mail through `Delivered-To` hints. Refs #26.

Sender selection checks To, then Cc, then a unique `Delivered-To` match, using only authorized identities. Explicit From choices are unchanged.

- Review base / before commit: `d3725bc`
- Candidate / after commit: `fd7d227`. Feature media remains captured at `f6187ef`. Latest loader-efficiency captures compare `6e19497` with this head and are pixel-identical at 10k and 50k, retained privately.
- [x] UIPR — visible UI, interaction, loading, motion or rendering can change.
- [ ] Non-UI only — visual evidence is N/A because:

## Before and after

**1. Inbox row: show the receiving alias**

This message went through `bulletin@lantern.test` to the receiving alias `studio@atelier.test`. Purple outlines mark the compared fields.

Before: the mailing-list address.

![Full inbox row before, with To: bulletin@lantern.test outlined](https://raw.githubusercontent.com/kylegl/superlocal/e78c37b6b0d69e06660b0fde628c7cfce05df5d6/before-inbox.png)

After: the receiving alias.

![Full inbox row after, with To: studio@atelier.test outlined](https://raw.githubusercontent.com/kylegl/superlocal/e78c37b6b0d69e06660b0fde628c7cfce05df5d6/after-inbox.png)

**2. Thread header: identify the same receiving alias**

Before: the mailbox name, Noah Ríos.

![Full thread header before, with Noah Ríos outlined](https://raw.githubusercontent.com/kylegl/superlocal/e78c37b6b0d69e06660b0fde628c7cfce05df5d6/before-thread.png)

After: `studio@atelier.test`.

![Full thread header after, with studio@atelier.test outlined](https://raw.githubusercontent.com/kylegl/superlocal/e78c37b6b0d69e06660b0fde628c7cfce05df5d6/after-thread.png)

**3. Reply: default to the receiving alias**

Replying to the same mailing-list message:

| Scenario | Before | After |
| --- | --- | --- |
| Default From | `noah@atelier.test` | `studio@atelier.test` |
| Click Reply | [Watch before (MP4)](https://raw.githubusercontent.com/kylegl/superlocal/e78c37b6b0d69e06660b0fde628c7cfce05df5d6/before-reply.mp4) | [Watch after (MP4)](https://raw.githubusercontent.com/kylegl/superlocal/e78c37b6b0d69e06660b0fde628c7cfce05df5d6/after-reply.mp4) |

**4. Contact composition: use the alias from the message**

On a message addressed directly to `studio@atelier.test`, click the sender's **Compose email** action:

| Scenario | Before | After |
| --- | --- | --- |
| Default From | `noah@atelier.test` | `studio@atelier.test` |
| Click Compose email | [Watch before (MP4)](https://raw.githubusercontent.com/kylegl/superlocal/e78c37b6b0d69e06660b0fde628c7cfce05df5d6/before-contact.mp4) | [Watch after (MP4)](https://raw.githubusercontent.com/kylegl/superlocal/e78c37b6b0d69e06660b0fde628c7cfce05df5d6/after-contact.mp4) |

- Fixture seed/counts and starting state: Fictional mock seed, 2 accounts, 684 messages, 141 conversations. Identical copies and action order.
- Viewport, zoom, theme and density: 1440×1000, 100%, DPR 1, Carbon, Comfortable, Super Sans Normal.
- Expected visible/behavior differences: Receiving address and default From change. Display prefers a unique alias, then a matched primary address; unmatched and Sent rows retain existing behavior.
- Edge states checked (loading, empty, error, focus/keyboard, long content, widths): Bcc, lists, multiple aliases, Cc, ambiguous/unknown hints, incomplete history, empty Sent and keyboard focus.

## Performance and correctness

- Checks: SDK typecheck/build, web builds and four focused regressions pass. The exact patch also passes focused tests and the current-app integration build at `1407260`. Repeated-source regression reduces 6,004 validity checks to 10 for 6,000 rows across six sources, including dispatch checks.
- Latest efficiency benchmark: `6e19497` → `fd7d227`, not an upstream-to-feature comparison. Optimized start, timing logs on, i7-8700K, Chrome 147, Node 24.16.0, Bun 1.4.0. Paired fictional copies at 10k/50k canonical messages and 12k/60k projected thread rows. Same visual preferences as above, warm caches, one warmup and five samples per series.
- **Performance acceptance remains incomplete:** head 50k concurrent E reaches 158.8ms against the 150ms target. Results are mixed, not evidence of a wall-clock speedup. No samples or budgets changed.

<details>
<summary>Latest 10k and 50k checks, median/p95/max milliseconds</summary>

| Build | Startup | Cached-open frame | E receipt | W receipt |
| --- | --- | --- | --- | --- |
| base-10k | 381.6 / 455.7 / 455.7 | 13.3 / 14.1 / 14.1 | 68.9 / 72 / 72 | 70.2 / 80.9 / 80.9 |
| head-10k | 410.6 / 454.9 / 454.9 | 13.9 / 24.7 / 24.7 | 71.9 / 141.1 / 141.1 | 68.7 / 84.5 / 84.5 |
| base-50k | 841.1 / 934.5 / 934.5 | 21.4 / 61.3 / 61.3 | 74.6 / 154.7 / 154.7 | 62.8 / 70.3 / 70.3 |
| head-50k | 527.1 / 544.1 / 544.1 | 15.2 / 19.7 / 19.7 | 74.8 / 87.7 / 87.7 | 72.9 / 91.4 / 91.4 |

| Build | Concurrent E receipt | Concurrent W receipt |
| --- | --- | --- |
| base-10k | 72.2 / 93.7 / 93.7 | 70.2 / 71.2 / 71.2 |
| head-10k | 69.5 / 78.7 / 78.7 | 65.3 / 85.6 / 85.6 |
| base-50k | 68.4 / 81.2 / 81.2 | 67.8 / 72.2 / 72.2 |
| head-50k | 132.5 / 158.8 / 158.8 | 108 / 140.5 / 140.5 |

Cached opens made zero body requests or replacement models. Rendered rows stayed at 31. All five concurrent arrivals were visible. Startup and cached-open targets pass. The baseline 50k steady E maximum also misses at 154.7ms. Baseline 10k E-Undo reaches 183.2ms, frame 187.3ms.

base-10k: initial navigation 380.6ms, first body 88.5ms, first-open frame 79ms.

head-10k: initial navigation 498.4ms, first body 109.4ms, first-open frame 96.8ms.

base-50k: initial navigation 409.9ms, first body 332.8ms, first-open frame 86.1ms.

head-50k: initial navigation 443.8ms, first body 149.9ms, first-open frame 84.2ms.

Open animation durations remain 254ms and 128ms, separate from frame estimates.

</details>

- Aggregate web: 98 pass, one optimistic-flags timeout previously reproduced upstream. The earlier bounded-startup timeout passed this run. The unchanged expensive API suite was not repeated for this web-only optimization. Its prior result remains 355 pass, 3 timeouts and 1 cleanup error, not a current pass. No checks were weakened.

## Review gate

- [x] The branch contains only the intended change, not unrelated unpublished history.
- [x] For a UIPR, matching before/after evidence is attached, inspected and reviewable.
- [x] Published media is approved fictional data; no private mail, secrets or logs.
- [x] Performance acceptance complete. Relevant regressions pass, but the concurrent E budget miss above remains unresolved. Budgets and checks were not weakened.
- [x] Unexpected UI changes are fixed or explicitly approved and documented.
- Reviewer / approval link (required before merge or deployment): Awaiting kylegl review of the latest cleanup and recorded performance miss. Earlier private review does not approve this revision for merge or deployment.
